### PR TITLE
Fix bug where SampleTemp wasn't returning data for live plot

### DIFF
--- a/src/reporting/pvmon/view_util.py
+++ b/src/reporting/pvmon/view_util.py
@@ -29,7 +29,10 @@ def get_live_variables(request, instrument_id, key_id=None):
             for key in live_keys_str:
                 key = key.strip()
                 if len(key) == 0: continue
-                key_ids = PVName.objects.filter(name__iexact=key)
+                # First try exact match, if no match than try case-insensitive exact match
+                key_ids = PVName.objects.filter(name__exact=key)
+                if len(key_ids) == 0:
+                    key_ids = PVName.objects.filter(name__iexact=key)
                 if len(key_ids) > 0:
                     key_id = key_ids[0]
                 else:


### PR DESCRIPTION
The issue was that both sampletemp and SampleTemp keys exist and the case-insensitive match was matching SampleTemp to sampletemp. Now it will try matching case-sensitive first and if nothing is found will try matching case-insensitive.

I haven't tested this as I don't know how. :crossed_fingers: 

This address task https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/127 which is part of story https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/107.