### PR TITLE
fixed static files 404 when spun up with docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3'
 services:
 
   nginx:
-    image: nginx
+    image: code.ornl.gov:4567/rse/images/nginx:1.21.1
     ports:
-      - 80:80
+      - "80:80"
     volumes:
       - web-static:/var/www/workflow/static
       - ./nginx/django.conf:/etc/nginx/conf.d/django.conf
@@ -20,7 +20,6 @@ services:
     ports: 
       - "8000:8000"
     volumes:
-      - web-django:/var/www/workflow/app
       - web-static:/var/www/workflow/static/
       - ./src/reporting/docker-entrypoint.sh:/usr/bin/docker-entrypoint.sh
     env_file:

--- a/nginx/django.conf
+++ b/nginx/django.conf
@@ -1,5 +1,5 @@
 upstream django {
-  server web:8000;
+  server webmon:8000;
 }
 
 server {
@@ -7,7 +7,7 @@ server {
   listen 80 default_server;
   listen [::]:80 default_server ipv6only=on;
 
-  server_name _;
+  server_name localhost;
 
   client_max_body_size 0;
 
@@ -26,6 +26,7 @@ server {
   }
 
   location /static/ {
+    autoindex on;
     alias /var/www/workflow/static/;
   }
 

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# remove default nginx config
+rm -f /etc/nginx/conf.d/default.conf
+
 # https://github.com/vishnubob/wait-for-it
 script=wait-for-it.sh
 url=https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 
 curl --silent -o $script $url
 chmod +x ./$script
-bash -c "./$script web:8000 --timeout=300"
+bash -c "./$script webmon:8000 --timeout=300"


### PR DESCRIPTION
This PR fixes some config issues with nginx that prevented it from starting, manifesting in static files not being served.

localhost:80, the true entry point for users, was unavailable due to nginx config issues, however you could still hit localhost:8000 directly to interact with the django server but it would not serve static files.