### PR TITLE
change default user name and add missing SQL init script

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 DEBUG=True
 DATABASE_NAME=workflow
-DATABASE_USER=workflow
-DATABASE_PASS=workflow
+DATABASE_USER=postgres
+DATABASE_PASS=postgres
 DATABASE_PORT=5432
 DATABASE_HOST=db
 SETTINGS_DIR=/var/www/workflow/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     restart: always
     image: postgres:9.6.22
     environment:
+      POSTGRES_DB: ${DATABASE_NAME}
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASS}
     ports:

--- a/src/Makefile
+++ b/src/Makefile
@@ -86,6 +86,11 @@ webapp: webapp/core
 	# Modify and copy the wsgi configuration
 	#cp reporting/apache/apache_django_wsgi.conf /etc/httpd/conf.d
 
+	# pass the init sql script to dbshell
+	cd $(prefix)/app; python3 manage.py dbshell < report/sql/indices.sql 
+	cd $(prefix)/app; python3 manage.py dbshell < report/sql/statusqueue.sql
+	cd $(prefix)/app; python3 manage.py dbshell < report/sql/stored_procs.sql
+
 	@echo "\n\nReady to go: run apachectl restart\n"
 
 .PHONY: check


### PR DESCRIPTION
This PR introduces the following two changes:

- add the missing init SQL script after upgrading to use `manage.py migration`
- change default user name so that the SQL script does not fail during webmon initialization.
