### PR TITLE
Add use case for viewing database directly

### DIFF
--- a/docs/usecases/Use-cases-database-view.md
+++ b/docs/usecases/Use-cases-database-view.md
@@ -1,0 +1,2 @@
+As a admin user (person with proper role rather than a specific account), I would like to type https://monitor.sns.gov/database and see the "django administration" / "site administration" page.
+Since it is an external app, being able to login and go there is all that is necessary.


### PR DESCRIPTION
While working on #59, I discovered that the database view was missing from docker. Adding this use case should make sure it doesn't get overlooked in testing.