### PR TITLE
[INF66] upgrade DB init to use fixture and admin command

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -73,8 +73,9 @@ webmon: webmon/core
 	#cp reporting/apache/apache_django_wsgi.conf /etc/httpd/conf.d
 
 	# pass the init sql script to dbshell
-	cd $(prefix)/app; python3 manage.py dbshell < pvmon/sql/stored_procs.sql
-	cd $(prefix)/app; python3 manage.py dbshell < report/sql/stored_procs.sql
+	# cd $(prefix)/app; python3 manage.py dbshell < pvmon/sql/stored_procs.sql
+	# cd $(prefix)/app; python3 manage.py dbshell < report/sql/stored_procs.sql
+	cd $(prefix)/app; python3 manage.py add_stored_procs
 
 	# use fixtures to load init data
 	cd $(prefix)/app; python3 manage.py loaddata fixtures/db_init.json

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,6 +50,7 @@ webmon/core: workflow  # the dependency on workflow doesn't make sense
 	cp -R reporting/users $(prefix)/app
 	cp -R reporting/templates $(prefix)/app
 	cp -R reporting/reporting_app $(prefix)/app
+	cp -R reporting/fixtures $(prefix)/app
 
 webmon: webmon/core
 	# Install apache config
@@ -60,7 +61,6 @@ webmon: webmon/core
 
 	# Create the database tables. The database itself must have been
 	# created on the server already
-
 	cd $(prefix)/app; python3 manage.py makemigrations --noinput
 	cd $(prefix)/app; python3 manage.py migrate --noinput
 	cd $(prefix)/app; python3 manage.py migrate --run-syncdb --noinput
@@ -73,9 +73,10 @@ webmon: webmon/core
 	#cp reporting/apache/apache_django_wsgi.conf /etc/httpd/conf.d
 
 	# pass the init sql script to dbshell
-	cd $(prefix)/app; python3 manage.py dbshell < report/sql/indices.sql
-	cd $(prefix)/app; python3 manage.py dbshell < report/sql/statusqueue.sql
 	cd $(prefix)/app; python3 manage.py dbshell < report/sql/stored_procs.sql
+
+	# use fixtures to load init data
+	cd $(prefix)/app; python3 manage.py loaddata fixtures/db_init.json
 
 	@echo "\n\nReady to go: run apachectl restart\n"
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -73,6 +73,7 @@ webmon: webmon/core
 	#cp reporting/apache/apache_django_wsgi.conf /etc/httpd/conf.d
 
 	# pass the init sql script to dbshell
+	cd $(prefix)/app; python3 manage.py dbshell < pvmon/sql/stored_procs.sql
 	cd $(prefix)/app; python3 manage.py dbshell < report/sql/stored_procs.sql
 
 	# use fixtures to load init data

--- a/src/reporting/fixtures/db_init.json
+++ b/src/reporting/fixtures/db_init.json
@@ -1,0 +1,393 @@
+[
+{
+    "model": "report.instrument",
+    "pk": 1,
+    "fields": {
+        "name": "common"
+    }
+},
+{
+    "model": "report.instrument",
+    "pk": 2,
+    "fields": {
+        "name": "hysa"
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 1,
+    "fields": {
+        "name": "POSTPROCESS.DATA_READY",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 2,
+    "fields": {
+        "name": "POSTPROCESS.INFO",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 3,
+    "fields": {
+        "name": "POSTPROCESS.ERROR",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 4,
+    "fields": {
+        "name": "CATALOG.DATA_READY",
+        "is_workflow_input": false
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 5,
+    "fields": {
+        "name": "CATALOG.STARTED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 6,
+    "fields": {
+        "name": "CATALOG.COMPLETE",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 7,
+    "fields": {
+        "name": "REDUCTION.DATA_READY",
+        "is_workflow_input": false
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 8,
+    "fields": {
+        "name": "REDUCTION.STARTED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 9,
+    "fields": {
+        "name": "REDUCTION.DISABLED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 10,
+    "fields": {
+        "name": "REDUCTION.NOT_NEEDED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 11,
+    "fields": {
+        "name": "REDUCTION.COMPLETE",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 12,
+    "fields": {
+        "name": "REDUCTION_CATALOG.DATA_READY",
+        "is_workflow_input": false
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 13,
+    "fields": {
+        "name": "REDUCTION_CATALOG.STARTED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 14,
+    "fields": {
+        "name": "REDUCTION_CATALOG.COMPLETE",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 15,
+    "fields": {
+        "name": "TRANSLATION.STARTED",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 16,
+    "fields": {
+        "name": "TRANSLATION.COMPLETE",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 17,
+    "fields": {
+        "name": "POSTPROCESS.CHECK",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 18,
+    "fields": {
+        "name": "REDUCTION.ERROR",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 19,
+    "fields": {
+        "name": "CATALOG.ERROR",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 20,
+    "fields": {
+        "name": "REDUCTION_CATALOG.ERROR",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 21,
+    "fields": {
+        "name": "REDUCTION.REQUEST",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 22,
+    "fields": {
+        "name": "CATALOG.REQUEST",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.statusqueue",
+    "pk": 23,
+    "fields": {
+        "name": "FERMI_REDUCTION.DATA_READY",
+        "is_workflow_input": true
+    }
+},
+{
+    "model": "report.task",
+    "pk": 1,
+    "fields": {
+        "instrument_id": 2,
+        "input_queue_id": 17,
+        "task_class": "workflow_process.WorkflowProcess",
+        "task_queue_ids": [],
+        "success_queue_ids": []
+    }
+},
+{
+    "model": "report.task",
+    "pk": 2,
+    "fields": {
+        "instrument_id": 2,
+        "input_queue_id": 1,
+        "task_class": " ",
+        "task_queue_ids": [
+            4,
+            7
+        ],
+        "success_queue_ids": [
+            6,
+            11
+        ]
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 1,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.dashboard_simple",
+        "path": "/dasmon/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:16.323Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 2,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.dashboard_simple",
+        "path": "/dasmon/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:18.472Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 3,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.dashboard_simple",
+        "path": "/dasmon/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:19.960Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 4,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.live_monitor",
+        "path": "/dasmon/hysa/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:22.044Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 5,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.dashboard_simple",
+        "path": "/dasmon/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:24.441Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 6,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.live_monitor",
+        "path": "/dasmon/common/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:25.503Z"
+    }
+},
+{
+    "model": "users.pageview",
+    "pk": 7,
+    "fields": {
+        "user": [
+            "postgres"
+        ],
+        "view": "dasmon.views.dashboard_simple",
+        "path": "/dasmon/",
+        "ip": "172.27.0.5",
+        "timestamp": "2022-02-01T16:47:28.384Z"
+    }
+},
+{
+    "model": "dasmon.parameter",
+    "pk": 1,
+    "fields": {
+        "name": "system_dasmon_listener_pid",
+        "monitored": true
+    }
+},
+{
+    "model": "dasmon.parameter",
+    "pk": 2,
+    "fields": {
+        "name": "system_workflowmgr",
+        "monitored": true
+    }
+},
+{
+    "model": "dasmon.parameter",
+    "pk": 3,
+    "fields": {
+        "name": "system_workflowmgr_pid",
+        "monitored": true
+    }
+},
+{
+    "model": "dasmon.statusvariable",
+    "pk": 1,
+    "fields": {
+        "instrument_id": 1,
+        "key_id": 1,
+        "value": "96",
+        "timestamp": "2022-02-01T16:47:18.597Z"
+    }
+},
+{
+    "model": "dasmon.statusvariable",
+    "pk": 2,
+    "fields": {
+        "instrument_id": 1,
+        "key_id": 1,
+        "value": "96",
+        "timestamp": "2022-02-01T16:49:18.566Z"
+    }
+},
+{
+    "model": "dasmon.statuscache",
+    "pk": 1,
+    "fields": {
+        "instrument_id": 1,
+        "key_id": 1,
+        "value": "96",
+        "timestamp": "2022-02-01T16:49:18.566Z"
+    }
+},
+{
+    "model": "dasmon.statuscache",
+    "pk": 2,
+    "fields": {
+        "instrument_id": 1,
+        "key_id": 2,
+        "value": "0",
+        "timestamp": "2022-02-01T16:45:59.521Z"
+    }
+},
+{
+    "model": "dasmon.statuscache",
+    "pk": 3,
+    "fields": {
+        "instrument_id": 1,
+        "key_id": 3,
+        "value": "100",
+        "timestamp": "2022-02-01T16:45:59.530Z"
+    }
+}
+]

--- a/src/reporting/report/management/commands/add_stored_procs.py
+++ b/src/reporting/report/management/commands/add_stored_procs.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from django.core.management.base import BaseCommand
 from django.db import connection
 

--- a/src/reporting/report/management/commands/add_stored_procs.py
+++ b/src/reporting/report/management/commands/add_stored_procs.py
@@ -1,0 +1,233 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+# error_rate and run_rate are taken from report/sql/stored_procs.sql
+error_rate_sql = """
+CREATE OR REPLACE FUNCTION error_rate(instrument_id bigint)
+RETURNS refcursor AS
+$BODY$DECLARE
+ref refcursor;
+BEGIN
+OPEN ref FOR
+SELECT MAX(TIMESTAMP) AS TIME, COUNT(*)
+FROM report_error t
+    INNER JOIN (
+    SELECT 
+        TRUNC(EXTRACT(EPOCH FROM report_runstatus.created_on-LOCALTIMESTAMP)/3600) AS TIMESTAMP, report_error.id
+    FROM report_error
+    INNER JOIN report_runstatus
+    ON report_error.run_status_id_id=report_runstatus.id
+    INNER JOIN report_datarun
+    ON report_runstatus.run_id_id=report_datarun.id
+    WHERE
+        (report_datarun.instrument_id_id = instrument_id AND 
+        report_runstatus.created_on >= LOCALTIMESTAMP-INTERVAL '1 DAY')
+    ) m ON t.id = m.id
+    GROUP BY timestamp;
+RETURN ref;
+END
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+ALTER FUNCTION error_rate(bigint)
+OWNER TO postgres;
+"""
+
+run_rate_sql = """
+CREATE OR REPLACE FUNCTION run_rate(instrument_id bigint)
+RETURNS refcursor AS
+$BODY$
+DECLARE
+ref refcursor;
+BEGIN
+OPEN ref FOR
+SELECT MAX(TIMESTAMP) AS TIME, COUNT(*)
+FROM report_datarun t
+    INNER JOIN (
+    SELECT 
+        TRUNC(EXTRACT(EPOCH FROM report_datarun.created_on-LOCALTIMESTAMP)/3600) AS TIMESTAMP, report_datarun.id
+    FROM report_datarun 
+    WHERE 
+        (report_datarun.instrument_id_id = instrument_id AND report_datarun.created_on >= LOCALTIMESTAMP-INTERVAL '1 DAY' )
+    ) m ON t.id = m.id
+    GROUP BY timestamp;
+RETURN ref;
+END;$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+ALTER FUNCTION run_rate(bigint)
+OWNER TO postgres;
+"""
+
+# pv_update, pv_update2, are taken from pvmon/sql/stored_procs.sql
+pv_update_sql = """
+CREATE OR REPLACE FUNCTION "pvUpdate"(pv_name character varying, value double precision, status bigint, update_time bigint)
+RETURNS void AS
+$BODY$DECLARE
+n_count numeric;
+n_id bigint;
+new_value double precision;
+new_time bigint;
+BEGIN
+new_value := value;
+new_time := update_time;
+-- Create the parameter name entry if it doesn't already exist
+SELECT COUNT(*)
+    FROM pvmon_pvname
+    INTO n_count
+    WHERE pvmon_pvname.name = pv_name;
+IF n_count = 0 THEN
+    INSERT INTO pvmon_pvname (name, monitored) VALUES (pv_name, true);
+END IF;
+-- Get the ID from the parameter name table
+SELECT id
+    FROM pvmon_pvname
+    INTO n_id
+    WHERE pvmon_pvname.name = pv_name;
+-- Add the entry for the new value
+INSERT INTO pvmon_pv (name_id, value, status, update_time)
+    VALUES (n_id, new_value, status, update_time);
+-- Cache the latest values
+SELECT COUNT(*)
+    FROM pvmon_pvcache
+    INTO n_count
+    WHERE pvmon_pvcache.name_id = n_id;
+IF n_count = 0 THEN
+    INSERT INTO pvmon_pvcache (name_id, value, status, update_time)
+    VALUES (n_id, value, status, update_time);
+ELSE
+    UPDATE pvmon_pvcache
+    SET value=new_value, update_time=new_time
+    WHERE name_id = n_id;
+END IF;
+END;$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+ALTER FUNCTION "pvUpdate"(character varying, double precision, bigint, bigint)
+OWNER TO postgres;
+"""
+
+pv_update2_sql = """
+CREATE OR REPLACE FUNCTION "pvUpdate"(instrument character varying, pv_name character varying, value double precision, status bigint, update_time bigint)
+RETURNS void AS
+$BODY$
+DECLARE
+n_count  numeric;
+n_id bigint;
+n_instrument bigint;
+new_value double precision;
+new_time bigint;
+BEGIN
+new_value := value;
+new_time := update_time;
+-- Create the parameter name entry if it doesn't already exist
+SELECT COUNT(*)
+    FROM pvmon_pvname
+    INTO n_count
+    WHERE pvmon_pvname.name = pv_name;
+IF n_count = 0 THEN
+    INSERT INTO pvmon_pvname (name, monitored) VALUES (pv_name, true);
+END IF;
+-- Get the ID from the parameter name table
+SELECT id
+    FROM pvmon_pvname
+    INTO n_id
+    WHERE pvmon_pvname.name = pv_name;
+-- Get the instrument ID
+SELECT id
+    FROM report_instrument
+    INTO n_instrument
+    WHERE report_instrument.name = lower(instrument);
+-- Add the entry for the new value
+INSERT INTO pvmon_pv (instrument_id, name_id, value, status, update_time)
+    VALUES (n_instrument, n_id, new_value, status, new_time);
+-- Cache the latest values
+SELECT COUNT(*)
+    FROM pvmon_pvcache
+    INTO n_count
+    WHERE pvmon_pvcache.instrument_id=n_instrument AND pvmon_pvcache.name_id = n_id;
+IF n_count = 0 THEN
+    INSERT INTO pvmon_pvcache (instrument_id, name_id, value, status, update_time)
+    VALUES (n_instrument, n_id, new_value, status, new_time);
+ELSE
+    UPDATE pvmon_pvcache
+    SET value=new_value, update_time=new_time
+    WHERE name_id = n_id AND instrument_id = n_instrument;
+END IF;
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE
+COST 100;
+ALTER FUNCTION "pvUpdate"(character varying, character varying, double precision, bigint, bigint)
+OWNER TO postgres;
+"""
+
+pvstring_update_sql = """
+CREATE OR REPLACE FUNCTION "pvStringUpdate"(instrument character varying, pv_name character varying, value character varying, status bigint, update_time bigint)
+  RETURNS void AS
+$BODY$
+DECLARE
+  n_count  numeric;
+  n_id bigint;
+  n_instrument bigint;
+  new_value character varying;
+  new_time bigint;
+BEGIN
+  new_value := value;
+  new_time := update_time;
+  -- Create the parameter name entry if it doesn't already exist
+  SELECT COUNT(*)
+    FROM pvmon_pvname
+    INTO n_count
+    WHERE pvmon_pvname.name = pv_name;
+  IF n_count = 0 THEN
+    INSERT INTO pvmon_pvname (name, monitored) VALUES (pv_name, true);
+  END IF;
+  -- Get the ID from the parameter name table
+  SELECT id
+    FROM pvmon_pvname
+    INTO n_id
+    WHERE pvmon_pvname.name = pv_name;
+  -- Get the instrument ID
+  SELECT id
+    FROM report_instrument
+    INTO n_instrument
+    WHERE report_instrument.name = lower(instrument);
+  -- Add the entry for the new value
+  INSERT INTO pvmon_pvstring (instrument_id, name_id, value, status, update_time)
+    VALUES (n_instrument, n_id, new_value, status, new_time);
+  -- Cache the latest values
+  SELECT COUNT(*)
+    FROM pvmon_pvstringcache
+    INTO n_count
+    WHERE pvmon_pvstringcache.instrument_id=n_instrument AND pvmon_pvstringcache.name_id = n_id;
+  IF n_count = 0 THEN
+    INSERT INTO pvmon_pvstringcache (instrument_id, name_id, value, status, update_time)
+      VALUES (n_instrument, n_id, new_value, status, new_time);
+  ELSE
+    UPDATE pvmon_pvstringcache
+      SET value=new_value, update_time=new_time
+      WHERE name_id = n_id AND instrument_id = n_instrument;
+  END IF;
+END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+ALTER FUNCTION "pvStringUpdate"(character varying, character varying, character varying, bigint, bigint)
+  OWNER TO postgres;
+"""
+
+
+class Command(BaseCommand):
+    help = "add additional stored procedures to backend database"
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            # report/sql/stored_proces.sql
+            cursor.execute(error_rate_sql)
+            cursor.execute(run_rate_sql)
+            # pvmon/sql/stored_proces.sql
+            cursor.execute(pv_update_sql)
+            cursor.execute(pv_update2_sql)
+            cursor.execute(pvstring_update_sql)


### PR DESCRIPTION
- Original Gitlab Enabler: [INF66](https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor/-/issues/66)

This PR introduces the following changes:

- switching to use django data fixture, `manage.py loaddata` to initialize the backend database
- switching to use admin command, `manage.py add_stored_procs` to add the additional stored procedures, which are used to
  - efficiently generating the run_rate and error_rate histogram for each instrument
  - allow DASMON to add PVs directly to db via various pv update stored procedure at the database level