### PR TITLE
Add PV test generator container

### DIFF
--- a/Dockerfile.pv_test_gen
+++ b/Dockerfile.pv_test_gen
@@ -1,0 +1,3 @@
+FROM continuumio/miniconda3
+RUN python -m pip install web-monitor-pv-generator==0.2.0 -i https://code.ornl.gov/api/v4/projects/10878/packages/pypi/simple
+CMD "webmonitor_pv_tester"

--- a/docker-compose.localdev.yml
+++ b/docker-compose.localdev.yml
@@ -88,6 +88,16 @@ services:
     depends_on:
       - activemq
 
+  amq_pv_gen:
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile.pv_test_gen
+    depends_on:
+      - db
+    env_file:
+      - .env
+
   catalog_process:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,16 @@ services:
     depends_on:
       - activemq
 
+  amq_pv_gen:
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile.pv_test_gen
+    depends_on:
+      - db
+    env_file:
+      - .env
+
   catalog_process:
     build:
       context: .


### PR DESCRIPTION
This adds the PV test generator from https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor-test-pv-generator

To test: 
Run with docker-compose, go to the instrument PV's page and you should see PV coming in.

![2022-03-09-133223_1714x1407_scrot](https://user-images.githubusercontent.com/5595210/157507939-27f8c014-2222-4554-be67-84f586fb5b21.png)


https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor/-/issues/129