### PR TITLE
Fix missing django settings in systemtests

### DIFF
--- a/src/dasmon_app/dasmon_listener/listener_daemon.py
+++ b/src/dasmon_app/dasmon_listener/listener_daemon.py
@@ -24,10 +24,10 @@ from .amq_consumer import Client, Listener  # noqa: E402
 
 # Daemon imports
 from workflow.daemon import Daemon  # noqa: E402
-from .settings import brokers  # noqa: E402
-from .settings import amq_user  # noqa: E402
-from .settings import amq_pwd  # noqa: E402
-from .settings import queues  # noqa: E402
+from .settings import BROKERS  # noqa: E402
+from .settings import AMQ_USER  # noqa: E402
+from .settings import AMQ_PWD  # noqa: E402
+from .settings import QUEUES  # noqa: E402
 
 
 class DasMonListenerDaemon(Daemon):
@@ -39,7 +39,7 @@ class DasMonListenerDaemon(Daemon):
         """
         Run the dasmon listener daemon
         """
-        c = Client(brokers, amq_user, amq_pwd, queues, "dasmon_listener")
+        c = Client(BROKERS, AMQ_USER, AMQ_PWD, QUEUES, "dasmon_listener")
         c.set_listener(Listener())
         c.listen_and_wait(0.01)
 

--- a/src/dasmon_app/dasmon_listener/settings.py
+++ b/src/dasmon_app/dasmon_listener/settings.py
@@ -33,13 +33,13 @@ INSTALLED_APPS = (
 
 # ActiveMQ settings
 
-amq_user = os.environ.get("ICAT_USER")
-amq_pwd = os.environ.get("ICAT_PASS")
+AMQ_USER = os.environ.get("ICAT_USER")
+AMQ_PWD = os.environ.get("ICAT_PASS")
 
 # List of brokers
 default_brokers = [("amqbroker1.sns.gov", 61613), ("amqbroker2.sns.gov", 61613)]
 env_amq_broker = os.environ.get("AMQ_BROKER", json.dumps(default_brokers))
-brokers = list(map(tuple, json.loads(env_amq_broker)))  # noqa: F811
+BROKERS = list(map(tuple, json.loads(env_amq_broker)))  # noqa: F811
 
 PING_TOPIC = "/topic/SNS.COMMON.STATUS.PING"
 ACK_TOPIC = "/topic/SNS.COMMON.STATUS.ACK"
@@ -60,4 +60,4 @@ default_queues = [
     "/topic/ADARA.SIGNAL.DASMON.0",
 ]
 env_amq_queue = os.environ.get("AMQ_QUEUE", json.dumps(default_queues))
-queues = json.loads(env_amq_queue)
+QUEUES = json.loads(env_amq_queue)

--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -303,10 +303,10 @@ REDUCTION_SCRIPT_CREATION_QUEUE = "/queue/REDUCTION.CREATE_SCRIPT"
 # activemq configuration
 default_brokers = [("amqbroker1.sns.gov", 61613), ("amqbroker2.sns.gov", 61613)]
 env_amq_broker = environ.get("AMQ_BROKER", json.dumps(default_brokers))
-brokers = list(map(tuple, json.loads(env_amq_broker)))
+BROKERS = list(map(tuple, json.loads(env_amq_broker)))
 
-icat_user = environ.get("ICAT_USER")
-icat_passcode = environ.get("ICAT_PASS")
+ICAT_USER = environ.get("ICAT_USER")
+ICAT_PASSCODE = environ.get("ICAT_PASS")
 
 HELPLINE_EMAIL = "adara_support@ornl.gov"
 

--- a/src/webmon_app/reporting/reporting_app/view_util.py
+++ b/src/webmon_app/reporting/reporting_app/view_util.py
@@ -17,8 +17,8 @@ def send_activemq_message(destination, data):
     """
     import stomp
 
-    conn = stomp.Connection(host_and_ports=settings.brokers)
-    conn.connect(settings.icat_user, settings.icat_passcode, wait=True)
+    conn = stomp.Connection(host_and_ports=settings.BROKERS)
+    conn.connect(settings.ICAT_USER, settings.ICAT_PASSCODE, wait=True)
     conn.send(destination, data, persistent="true")
     conn.disconnect()
 

--- a/src/workflow_app/workflow/database/settings.py
+++ b/src/workflow_app/workflow/database/settings.py
@@ -25,15 +25,15 @@ INSTALLED_APPS = ("workflow.database.report",)
 
 
 # ActiveMQ settings
-icat_user = os.environ.get("ICAT_USER")
-icat_passcode = os.environ.get("ICAT_PASS")
-wkflow_user = os.environ.get("WORKFLOW_USER")
-wkflow_passcode = os.environ.get("WORKFLOW_PASS")
-worker_user = os.environ.get("WORKER_USER")
-worker_passcode = os.environ.get("WORKER_PASS")
+ICAT_USER = os.environ.get("ICAT_USER")
+ICAT_PASSCODE = os.environ.get("ICAT_PASS")
+WKFLOW_USER = os.environ.get("WORKFLOW_USER")
+WKFLOW_PASSCODE = os.environ.get("WORKFLOW_PASS")
+WORKER_USER = os.environ.get("WORKER_USER")
+WORKER_PASSCODE = os.environ.get("WORKER_PASS")
 
 
 # Configure activemq brokers
 default_brokers = [("amqbroker1.sns.gov", 61613), ("amqbroker2.sns.gov", 61613)]
 env_amq_broker = os.environ.get("AMQ_BROKER", json.dumps(default_brokers))
-brokers = list(map(tuple, json.loads(env_amq_broker)))
+BROKERS = list(map(tuple, json.loads(env_amq_broker)))

--- a/src/workflow_app/workflow/settings.py
+++ b/src/workflow_app/workflow/settings.py
@@ -15,10 +15,10 @@ CATALOG_DATA_READY = "CATALOG.DATA_READY"
 REDUCTION_DATA_READY = "REDUCTION.DATA_READY"
 REDUCTION_CATALOG_DATA_READY = "REDUCTION_CATALOG.DATA_READY"
 
-wkflow_user = os.environ.get("WORKFLOW_USER")
-wkflow_passcode = os.environ.get("WORKFLOW_PASS")
+WKFLOW_USER = os.environ.get("WORKFLOW_USER")
+WKFLOW_PASSCODE = os.environ.get("WORKFLOW_PASS")
 
 # configure activemq brokers
 default_brokers = [("amqbroker1.sns.gov", 61613), ("amqbroker2.sns.gov", 61613)]
 env_amq_broker = os.environ.get("AMQ_BROKER", json.dumps(default_brokers))
-brokers = list(map(tuple, json.loads(env_amq_broker)))
+BROKERS = list(map(tuple, json.loads(env_amq_broker)))

--- a/src/workflow_app/workflow/sns_post_processing.py
+++ b/src/workflow_app/workflow/sns_post_processing.py
@@ -13,7 +13,7 @@ from workflow.amq_listener import Listener
 
 from .daemon import Daemon  # noqa: F401
 from .database import transactions  # noqa: F401
-from .settings import LOGGING_LEVEL, brokers, wkflow_user, wkflow_passcode
+from .settings import LOGGING_LEVEL, BROKERS, WKFLOW_USER, WKFLOW_PASSCODE
 
 # Set log level
 logging.getLogger().setLevel(LOGGING_LEVEL)
@@ -71,9 +71,9 @@ class WorkflowDaemon(Daemon):
             workflow_check = True
 
         c = Client(
-            brokers,
-            wkflow_user,
-            wkflow_passcode,
+            BROKERS,
+            WKFLOW_USER,
+            WKFLOW_PASSCODE,
             workflow_check=workflow_check,
             check_frequency=check_frequency,
             workflow_recovery=self._workflow_recovery,
@@ -83,7 +83,7 @@ class WorkflowDaemon(Daemon):
         )
 
         listener = Listener(use_db_tasks=self._flexible_tasks, auto_ack=auto_ack)
-        listener.set_amq_user(brokers, wkflow_user, wkflow_passcode)
+        listener.set_amq_user(BROKERS, WKFLOW_USER, WKFLOW_PASSCODE)
         c.set_listener(listener)
         c.listen_and_wait(0.1)
 

--- a/tests/amq_looper.py
+++ b/tests/amq_looper.py
@@ -7,10 +7,10 @@ import time
 import stomp
 import json
 import settings
-from settings import brokers as amq_brokers
-from settings import amq_user
-from settings import amq_pwd
-from settings import queues as amq_queues
+from settings import BROKERS as amq_brokers
+from settings import AMQ_USER
+from settings import AMQ_PWD
+from settings import QUEUES as amq_queues
 
 import logging
 import logging.handlers
@@ -221,7 +221,7 @@ class Client(object):
 
 if __name__ == "__main__":
     logging.warning("Starting")
-    client = Client(amq_brokers, amq_user, amq_pwd, amq_queues, "amq_looper")
+    client = Client(amq_brokers, AMQ_USER, AMQ_PWD, amq_queues, "amq_looper")
     listener = Listener()
     client.set_listener(listener)
     client.listen_and_wait()

--- a/tests/simple_producer.py
+++ b/tests/simple_producer.py
@@ -5,7 +5,7 @@ import stomp
 import json
 import time
 import argparse
-from workflow.settings import brokers, icat_user, icat_passcode
+from workflow.settings import BROKERS, ICAT_USER, ICAT_PASSCODE
 
 
 def send(destination, message, persistent="true"):
@@ -17,18 +17,18 @@ def send(destination, message, persistent="true"):
     """
     if stomp.__version__[0] < 4:
         conn = stomp.Connection(
-            host_and_ports=brokers,
-            user=icat_user,
-            passcode=icat_passcode,
+            host_and_ports=BROKERS,
+            user=ICAT_USER,
+            passcode=ICAT_PASSCODE,
             wait_on_receipt=True,
         )
         conn.start()
         conn.connect()
         conn.send(destination=destination, message=message, persistent=persistent)
     else:
-        conn = stomp.Connection(host_and_ports=brokers)
+        conn = stomp.Connection(host_and_ports=BROKERS)
         conn.start()
-        conn.connect(icat_user, icat_passcode, wait=True)
+        conn.connect(ICAT_USER, ICAT_PASSCODE, wait=True)
         conn.send(destination, message)
     conn.disconnect()
 

--- a/tests/workflow_command.py
+++ b/tests/workflow_command.py
@@ -3,7 +3,7 @@
     NOTE: Only works for runs that are already in the DB
 """
 from report.models import Instrument, DataRun
-from workflow.settings import brokers, icat_user, icat_passcode
+from workflow.settings import BROKERS, ICAT_USER, ICAT_PASSCODE
 import argparse
 import sys
 import os
@@ -33,18 +33,18 @@ def send(destination, message, persistent="true"):
     """
     if stomp.__version__[0] < 4:
         conn = stomp.Connection(
-            host_and_ports=brokers,
-            user=icat_user,
-            passcode=icat_passcode,
+            host_and_ports=BROKERS,
+            user=ICAT_USER,
+            passcode=ICAT_PASSCODE,
             wait_on_receipt=True,
         )
         conn.start()
         conn.connect()
         conn.send(destination=destination, message=message, persistent=persistent)
     else:
-        conn = stomp.Connection(host_and_ports=brokers)
+        conn = stomp.Connection(host_and_ports=BROKERS)
         conn.start()
-        conn.connect(icat_user, icat_passcode, wait=True)
+        conn.connect(ICAT_USER, ICAT_PASSCODE, wait=True)
         conn.send(destination, message)
     conn.disconnect()
 


### PR DESCRIPTION
Some settings were not being found when running system tests. Django [requires uppercase settings](https://docs.djangoproject.com/en/4.0/topics/settings/#creating-your-own-settings) but these settings were defined as lowercase which prevented them from being imported. 