### PR TITLE
Update webmon Dockerfile to start the same as the others

### DIFF
--- a/Dockerfile.webmon
+++ b/Dockerfile.webmon
@@ -1,11 +1,9 @@
 FROM continuumio/miniconda3:4.10.3p1
 
-RUN apt-get update && apt-get install -y vim less
-
-WORKDIR /usr/src/webmon
-
 COPY conda_environment.yml .
 RUN conda env update --name base --file conda_environment.yml
+
+WORKDIR /usr/src/webmon
 
 # copy the necessary wheels and the Makefile which knows the dependency order
 COPY ./src/webmon_app/dist/django_nscd_webmon-*-none-any.whl .


### PR DESCRIPTION
This allows the reuse of the first three layers and speeds up the docker-compose build. Updating the conda environment is the slowest step and we should avoid repeating that.

You can verify that the layers are being reused by running and seeing the image is now the same for the `conda env update --name base --fi...` line with

```
docker history data_workflow_dasmon
docker history data_workflow_webmon
```