### PR TITLE
Split the list of instruments into two columns in the extended dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,25 +44,25 @@ check: ## Check python dependencies
 	@python -c "import psycopg2" || echo "\nWARNING: psycopg2 is not installed: http://initd.org/psycopg\n"
 	@python -c "import stomp" || echo "\nERROR: stomp.py is not installed: http://code.google.com/p/stomppy\n"
 
-wheel/dasmon: ## python wheel for service "dasmon"
+wheel/dasmon: ## create or update python wheel for service "dasmon"
 	cd src/dasmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/dasmon_app && python -m build --no-isolation --wheel
 	# verify it is correct
 	cd src/dasmon_app && check-wheel-contents dist/django_nscd_dasmon-*.whl
 
-wheel/webmon: ## python wheel for service "webmon"
+wheel/webmon: ## create or update python wheel for service "webmon"
 	cd src/webmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/webmon_app && python -m build --no-isolation --wheel
 	# verify it is correct - ignoring duplicate file check
 	cd src/webmon_app && check-wheel-contents dist/django_nscd_webmon-*.whl
 
-wheel/workflow: ## python wheel for service "workflow"
+wheel/workflow: ## create or update python wheel for service "workflow"
 	cd src/workflow_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/workflow_app && python -m build --no-isolation --wheel
 	# verify it is correct
 	cd src/workflow_app && check-wheel-contents dist/django_nscd_workflow-*.whl
 
-wheel/all:  wheel/dasmon wheel/webmon wheel/workflow ##  python wheels for all servicess
+wheel/all:  wheel/dasmon wheel/webmon wheel/workflow ## create or update  python wheels for all servicess
 
 install/workflow: check
 	# Install the workflow manager, which defines the database schema
@@ -112,7 +112,7 @@ SNSdata.tar.gz:
 	# it needs to be removed when the directory changes
 	tar czf SNSdata.tar.gz -C tests/data/ .
 
-localdev/up: ## update python wheels, create images, and start containers for local development
+localdev/up: ## create images and start containers for local development. Doesn't update python wheels, though.
 	\cp docker-compose.localdev.yml docker-compose.yml
 	docker-compose up --build
 

--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -36,8 +36,12 @@ def dashboard(request):
     """
     # Get the system health status
     global_status_url = reverse(settings.LANDING_VIEW, args=[])
+    instrument_data = view_util.get_instrument_status_summary()
+    cutoff = int(len(instrument_data) / 2)
     template_values = {
-        "instruments": view_util.get_instrument_status_summary(),
+        "instruments": instrument_data,
+        "instruments_left": instrument_data[:cutoff],
+        "instruments_right": instrument_data[cutoff:],
         "data": view_util.get_dashboard_data(),
         "breadcrumbs": "<a href='%s'>home</a> &rsaquo; dashboard" % global_status_url,
         "postprocess_status": view_util.get_system_health(),

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -65,24 +65,44 @@
 
 <p>
 List of instruments:<br>
+
   <table class="dashboard_table">
-    <thead>
-      <tr>
-        <th style="min-width:75px">Instrument</th> <th>Status</th> <th>Processing</th>
-      </tr>
-    </thead>
-    <tbody class='status_box'>
-    {% for item in instruments %}
-      <tr>
-        <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
-        <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
-        <td>
-          <div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div>
-        </td>
-      </tr>
-    {% endfor %}
-    </tbody>
+    <!-- Left column of instruments -->
+    <td><table class="dashboard_table">
+        <!-- Column headers -->
+        <thead><tr><th style="min-width:75px">Instrument</th> <th>Status</th> <th>Processing</th></tr></thead>
+        <!-- Loop over each instrument producing one row -->
+        <tbody class='status_box'>
+        {% for item in instruments_left %}
+            <tr>
+                <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
+                <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
+                <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table></td>
+
+    <!-- Insert some space between left and right columns of instruments -->
+    <td style="min-width:75px"></td>
+
+    <!-- Right column of instruments -->
+    <td><table class="dashboard_table">
+        <!-- Column headers -->
+        <thead><tr><th style="min-width:75px">Instrument</th> <th>Status</th> <th>Processing</th></tr></thead>
+        <!-- Loop over each instrument producing one row -->
+        <tbody class='status_box'>
+        {% for item in instruments_right %}
+            <tr>
+                <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
+                <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
+                <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table></td>
   </table>
+
   <script id="source" language="javascript" type="text/javascript">plot_rates();</script>
   {% endblock %}
 {% block nocontent %}{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+# third-party imports
+import pytest
+
+# standard imports
+import requests
+
+
+@pytest.fixture(scope="session")
+def request_page():
+    r"""Post an HTTP request to a server that requires prior login
+
+    :param subdirectory: requested page, e.g. "/pvmon/arcs/" in URL "http://localhost/users/login?next=/pvmon/arcs/"
+    :param username: required for login
+    :param password: required for login
+    :param domain: domain of the application, default is "localhost",
+        e.g. "http://localhost/users/login?next=/pvmon/arcs/"
+
+    :returns requests.Response: server's response to the HTTP request
+    """
+
+    def _request_page(subdirectory, username, password, domain="localhost"):
+        url = f"http://{domain}/users/login?next="
+        client = requests.session()
+
+        # Retrieve the CSRF token first
+        client.get(url)  # sets the cookie
+        csrf_token = client.cookies["csrftoken"]
+
+        login_data = dict(username=username, password=password, csrfmiddlewaretoken=csrf_token)
+        return client.post(url + subdirectory, data=login_data, timeout=None)
+
+    return _request_page
+
+
+@pytest.fixture(scope="session")
+def HTTPText():
+    r"""A class encapsulating a set of helper functions to be applied to an imput HTML string.
+
+    Example:
+        text = HTTPText(html_test)
+        assert "HTML" in text
+
+    :param str html_text: the input HTML string
+
+    :returns HTTPText object:
+    """
+
+    class _HTTPText(object):
+        def __init__(self, html_text: str):
+            self.text = html_text
+
+        def __contains__(self, substring: str):
+            r"""check HTML string contains a substring, but whitespaces are not considered
+            :param substring: substring to match
+            """
+            return substring.replace(" ", "") in self.text.replace(" ", "")
+
+    return _HTTPText

--- a/tests/test_extendend_dashboard.py
+++ b/tests/test_extendend_dashboard.py
@@ -1,0 +1,18 @@
+# third-party imports
+from django.conf import settings
+import pytest
+
+
+class TestExtendedDashboard:
+    def test_response(self, request_page, HTTPText):
+        response = request_page("/dasmon/dashboard/", settings.GENERAL_USER_USERNAME, settings.GENERAL_USER_PASSWORD)
+        assert response.ok
+
+        # Check double column of instruments
+        text = HTTPText(response.text)
+        for side in ["Right", "Left"]:
+            assert f"{side} column of instruments" in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,18 @@
+# third-party imports
+from django.conf import settings
+import pytest
+
+
+def test_request_page(request_page):
+    response = request_page("/dasmon/", settings.GENERAL_USER_USERNAME, settings.GENERAL_USER_PASSWORD)
+    assert response.ok
+
+
+def test_HTTPText(HTTPText):
+    text = HTTPText("on and on")
+    assert "on" in text
+    assert "ona" in text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
[<img src="https://img.shields.io/badge/web monitor Task 17 - complete - grey" >](https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor/-/issues/17)

### Testing
Build `LOCAL` environment and go to the extended dashboard page. It should distribute the three instruments into two columns and look like this:

<img src="https://user-images.githubusercontent.com/1136006/167047540-5bc96977-1f85-40de-bce4-54a3fdcf3502.PNG" width=500>

### Work Done
- [x] dashboard template HTML now splits list of instruments into two columns
