### PR TITLE
Add facility filtering on dashboard and simple dashboard

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -1135,6 +1135,7 @@ def get_instrument_status_summary():
                 "pvstreamer_status": pvstreamer_status,
                 "completeness": completeness,
                 "completeness_msg": message,
+                "facility": settings.FACILITY_INFO.get(i.name, "SNS"),
             }
         )
     return instrument_list

--- a/src/webmon_app/reporting/static/facility_filter.js
+++ b/src/webmon_app/reporting/static/facility_filter.js
@@ -1,0 +1,23 @@
+// Updates the displayed table rows depending on the value of the facility select element
+function filter_facility(selection_value) {
+    // "Reset" the table so that everything is shown.
+    var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
+        item.style.display = 'table-row';
+    });
+    
+    if (selection_value == "hfir") {
+        document.querySelectorAll('.SNS_instrument').forEach((item) => {
+            item.style.display = 'none';
+        });
+    } else if (selection_value == "sns") {
+        document.querySelectorAll('.HFIR_instrument').forEach((item) => {
+            item.style.display = 'none';
+        });
+    }
+}
+// Add filter_facility as the change event listener of the facility select element
+document.querySelector("#facility-select").addEventListener('change', (event) => {
+    filter_facility(event.target.value);
+});
+// Call filter_facility to handle page refreshes.
+filter_facility(document.querySelector("#facility-select").value);

--- a/src/webmon_app/reporting/static/facility_filter.js
+++ b/src/webmon_app/reporting/static/facility_filter.js
@@ -4,7 +4,7 @@ function filter_facility(selection_value) {
     var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
         item.style.display = 'table-row';
     });
-    
+
     if (selection_value == "hfir") {
         document.querySelectorAll('.SNS_instrument').forEach((item) => {
             item.style.display = 'none';

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -65,7 +65,12 @@
 
 <p>
 List of instruments:<br>
-
+  <label for="facility-select">Facility:</label>
+  <select name="facilities" id="facility-select">
+    <option value="all">All</option>
+    <option value="hfir">HFIR</option>
+    <option value="sns">SNS</option>
+  </select>
   <table class="dashboard_table">
     <!-- Left column of instruments -->
     <td><table class="dashboard_table">
@@ -74,7 +79,7 @@ List of instruments:<br>
         <!-- Loop over each instrument producing one row -->
         <tbody class='status_box'>
         {% for item in instruments_left %}
-            <tr>
+            <tr class='{{ item.facility }}_instrument instrument_row'>
                 <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
                 <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
                 <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
@@ -93,7 +98,7 @@ List of instruments:<br>
         <!-- Loop over each instrument producing one row -->
         <tbody class='status_box'>
         {% for item in instruments_right %}
-            <tr>
+            <tr class='{{ item.facility }}_instrument instrument_row'>
                 <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
                 <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
                 <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
@@ -102,7 +107,25 @@ List of instruments:<br>
         </tbody>
     </table></td>
   </table>
+  <script>
+    document.querySelector("#facility-select").addEventListener('change', (event) => {
+        var selection = event.target.value;
 
+        var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
+           item.style.display = 'table-row';
+        });
+
+        if (selection == "hfir") {
+            document.querySelectorAll('.SNS_instrument').forEach((item) => {
+                item.style.display = 'none';
+            });
+        } else if (selection == "sns") {
+            document.querySelectorAll('.HFIR_instrument').forEach((item) => {
+                item.style.display = 'none';
+            });
+        }
+    });
+  </script>
   <script id="source" language="javascript" type="text/javascript">plot_rates();</script>
   {% endblock %}
 {% block nocontent %}{% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -107,25 +107,7 @@ List of instruments:<br>
         </tbody>
     </table></td>
   </table>
-  <script>
-    document.querySelector("#facility-select").addEventListener('change', (event) => {
-        var selection = event.target.value;
-
-        var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
-           item.style.display = 'table-row';
-        });
-
-        if (selection == "hfir") {
-            document.querySelectorAll('.SNS_instrument').forEach((item) => {
-                item.style.display = 'none';
-            });
-        } else if (selection == "sns") {
-            document.querySelectorAll('.HFIR_instrument').forEach((item) => {
-                item.style.display = 'none';
-            });
-        }
-    });
-  </script>
+  <script language="javascript" type="text/javascript" src="/static/facility_filter.js"></script>
   <script id="source" language="javascript" type="text/javascript">plot_rates();</script>
   {% endblock %}
 {% block nocontent %}{% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
@@ -51,6 +51,12 @@
 
 <p>
 List of instruments:<br>
+<label for="facility-select">Facility:</label>
+<select name="facilities" id="facility-select">
+  <option value="all">All</option>
+  <option value="hfir">HFIR</option>
+  <option value="sns">SNS</option>
+</select>
 <table class="dashboard_table"><tr>
   <td><table class="dashboard_table">
     <thead>
@@ -60,7 +66,7 @@ List of instruments:<br>
     </thead>
     <tbody class='status_box'>
     {% for item in instruments_left %}
-      <tr>
+      <tr class='{{ item.facility }}_instrument instrument_row'>
         <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
         <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
       </tr>
@@ -76,7 +82,7 @@ List of instruments:<br>
     </thead>
     <tbody class='status_box'>
     {% for item in instruments_right %}
-      <tr>
+      <tr class='{{ item.facility }}_instrument instrument_row'>
         <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
         <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
       </tr>
@@ -85,6 +91,25 @@ List of instruments:<br>
   </table></td>
 
 </tr></table>
+<script>
+    document.querySelector("#facility-select").addEventListener('change', (event) => {
+        var selection = event.target.value;
+
+        var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
+           item.style.display = 'table-row';
+        });
+
+        if (selection == "hfir") {
+            document.querySelectorAll('.SNS_instrument').forEach((item) => {
+                item.style.display = 'none';
+            });
+        } else if (selection == "sns") {
+            document.querySelectorAll('.HFIR_instrument').forEach((item) => {
+                item.style.display = 'none';
+            });
+        }
+    });
+  </script>
 
   {% endblock %}
 {% block nocontent %}{% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
@@ -91,25 +91,6 @@ List of instruments:<br>
   </table></td>
 
 </tr></table>
-<script>
-    document.querySelector("#facility-select").addEventListener('change', (event) => {
-        var selection = event.target.value;
-
-        var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
-           item.style.display = 'table-row';
-        });
-
-        if (selection == "hfir") {
-            document.querySelectorAll('.SNS_instrument').forEach((item) => {
-                item.style.display = 'none';
-            });
-        } else if (selection == "sns") {
-            document.querySelectorAll('.HFIR_instrument').forEach((item) => {
-                item.style.display = 'none';
-            });
-        }
-    });
-  </script>
-
+<script language="javascript" type="text/javascript" src="/static/facility_filter.js"></script>
   {% endblock %}
 {% block nocontent %}{% endblock %}


### PR DESCRIPTION
https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor/-/issues/16

This pr adds a select element to both dashboards that lets you select a facility (choices are ALL, HFIR, SNS) and it will filter the instruments shown on the page to those that belong to said facility. One thing I'll note is that due to how the columns are done, they don't "auto-adjust" to fill just one column if there are no instruments currently shown in one of the columns. Also, the table header is present regardless of the amount of instruments shown. Those weren't part of any of the requirements though.

![facility filter ss](https://user-images.githubusercontent.com/30890419/168829610-a548a31a-ae3e-41df-ac3f-f4f81ff20230.png)

![instrument facility ss 2](https://user-images.githubusercontent.com/30890419/168829638-9e844714-5894-48e1-95de-2281c4dff01f.png)



