### PR TITLE
Change StatusCache to automatically update timestamp

### DIFF
--- a/src/dasmon_app/dasmon_listener/amq_consumer.py
+++ b/src/dasmon_app/dasmon_listener/amq_consumer.py
@@ -483,7 +483,6 @@ def store_and_cache_(instrument_id, key_id, value, timestamp=None, cache_only=Fa
     if len(value_string) > 128:
         value_string = value_string[:128]
 
-    datetime_timestamp = datetime.datetime.fromtimestamp(time.time()).replace(tzinfo=timezone.get_current_timezone())
     if cache_only is False:
         status_entry = StatusVariable(instrument_id=instrument_id, key_id=key_id, value=value_string)
         # Force the timestamp value as needed
@@ -496,20 +495,17 @@ def store_and_cache_(instrument_id, key_id, value, timestamp=None, cache_only=Fa
             except:  # noqa: E722
                 logging.error("Could not process timestamp [%s]: %s", timestamp, sys.exc_info()[1])
         status_entry.save()
-        datetime_timestamp = status_entry.timestamp
 
     # Update the latest value
     try:
         last_value = StatusCache.objects.filter(instrument_id=instrument_id, key_id=key_id).latest("timestamp")
         last_value.value = value_string
-        last_value.timestamp = datetime_timestamp
         last_value.save()
     except:  # noqa: E722
         last_value = StatusCache(
             instrument_id=instrument_id,
             key_id=key_id,
             value=value_string,
-            timestamp=datetime_timestamp,
         )
         last_value.save()
 

--- a/src/webmon_app/reporting/dasmon/models.py
+++ b/src/webmon_app/reporting/dasmon/models.py
@@ -38,7 +38,7 @@ class StatusCache(models.Model):
     instrument_id = models.ForeignKey(Instrument, on_delete=models.CASCADE)
     key_id = models.ForeignKey(Parameter, on_delete=models.CASCADE)
     value = models.CharField(max_length=128)
-    timestamp = models.DateTimeField("timestamp")
+    timestamp = models.DateTimeField("timestamp", auto_now=True)
 
 
 class ActiveInstrumentManager(models.Manager):


### PR DESCRIPTION
By setting `auto_now=True` for `StatusCache`, anytime it is saved the timestamp will automatically update, which is more reliable than manually updating it.

This fixes an issue seen in the test deployment where the timestamp is wrong in a few special cases when `cache_only=True`