### PR TITLE
Filter out user information from triggering gitlab

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -119,4 +119,4 @@ jobs:
           push: true
 
       - name: Trigger ORNL Deployment Pipeline
-        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=main https://code.ornl.gov/api/v4/projects/10858/trigger/pipeline
+        run: curl -X POST -F token=${{ secrets.GITLAB_TRIGGER_TOKEN }} -F ref=main https://code.ornl.gov/api/v4/projects/10858/trigger/pipeline | jq '. | del( .user )'


### PR DESCRIPTION
Ian sorted out the `jq` filter so we can hide the user information in the resulting diagnostics from triggering gitlab to do it's thing.