### PR TITLE
Refactor dashboard to allow more flexible filtering

### DIFF
--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -37,11 +37,8 @@ def dashboard(request):
     # Get the system health status
     global_status_url = reverse(settings.LANDING_VIEW, args=[])
     instrument_data = view_util.get_instrument_status_summary()
-    cutoff = int(len(instrument_data) / 2)
     template_values = {
         "instruments": instrument_data,
-        "instruments_left": instrument_data[:cutoff],
-        "instruments_right": instrument_data[cutoff:],
         "data": view_util.get_dashboard_data(),
         "breadcrumbs": "<a href='%s'>home</a> &rsaquo; dashboard" % global_status_url,
         "postprocess_status": view_util.get_system_health(),
@@ -64,10 +61,8 @@ def dashboard_simple(request):
     # Get the system health status
     global_status_url = reverse(settings.LANDING_VIEW, args=[])
     instrument_data = view_util.get_instrument_status_summary()
-    cutoff = int(len(instrument_data) / 2)
     template_values = {
-        "instruments_left": instrument_data[:cutoff],
-        "instruments_right": instrument_data[cutoff:],
+        "instruments": instrument_data,
         "breadcrumbs": "<a href='%s'>home</a> &rsaquo; dashboard" % global_status_url,
         "postprocess_status": view_util.get_system_health(),
         "update_url": reverse("dasmon:dashboard_update"),

--- a/src/webmon_app/reporting/static/dashboard.css
+++ b/src/webmon_app/reporting/static/dashboard.css
@@ -39,7 +39,7 @@
     border-left: 1px lightgray solid;
 }
 
-.heading_element:nth-child(1){ 
+.heading_element:nth-child(1){
     border-left: 0px lightgray solid;
 }
 
@@ -65,5 +65,3 @@
 #facility-select {
     width: 10%;
 }
-
-

--- a/src/webmon_app/reporting/static/dashboard.css
+++ b/src/webmon_app/reporting/static/dashboard.css
@@ -1,0 +1,69 @@
+.dashboard_parent {
+    width: fit-content;
+    margin-top: 2em;
+}
+
+.select_menu {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1em;
+}
+.select_menu label {
+    margin-top: 1em;
+}
+
+.column_heading_parent {
+    display: grid;
+    width: 100%;
+    grid-column-gap: 5em;
+}
+
+.first_column_heading {
+    width: 50%;
+    display: flex;
+    grid-row: 1;
+    grid-column: 1;
+}
+
+.second_column_heading {
+    width: 50%;
+    display: flex;
+    grid-row: 1;
+    grid-column: 2;
+}
+
+.heading_element {
+    display: inline;
+    min-width: 7em;
+    border-bottom: 1px lightgray solid;
+    border-left: 1px lightgray solid;
+}
+
+.heading_element:nth-child(1){ 
+    border-left: 0px lightgray solid;
+}
+
+.instrument_list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 5em;
+    margin-top: 1em;
+    width: 100%;
+}
+
+.instrument_entry {
+    display: flex;
+    margin-bottom: 1em;
+    align-items: center;
+}
+
+.entry_element {
+    display: inline;
+    min-width: 8.2em;
+}
+
+#facility-select {
+    width: 10%;
+}
+
+

--- a/src/webmon_app/reporting/static/dashboard_simple.css
+++ b/src/webmon_app/reporting/static/dashboard_simple.css
@@ -37,7 +37,7 @@
     border-left: 1px lightgray solid;
 }
 
-.heading_element:nth-child(1){ 
+.heading_element:nth-child(1){
     border-left: 0px lightgray solid;
 }
 
@@ -64,5 +64,3 @@
 #facility-select {
     width: 15%;
 }
-
-

--- a/src/webmon_app/reporting/static/dashboard_simple.css
+++ b/src/webmon_app/reporting/static/dashboard_simple.css
@@ -1,0 +1,68 @@
+.dashboard_parent {
+    width: 100%;
+    margin-top: 2em;
+}
+
+.select_menu {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1em;
+}
+.select_menu label {
+    margin-top: 1em;
+}
+
+.column_heading_parent {
+    display: grid;
+    width: 100%;
+    grid-column-gap: 5em;
+}
+
+.first_column_heading {
+    display: flex;
+    grid-row: 1;
+    grid-column: 1;
+}
+
+.second_column_heading {
+    display: flex;
+    grid-row: 1;
+    grid-column: 2;
+}
+
+.heading_element {
+    display: inline;
+    min-width: 7em;
+    border-bottom: 1px lightgray solid;
+    border-left: 1px lightgray solid;
+}
+
+.heading_element:nth-child(1){ 
+    border-left: 0px lightgray solid;
+}
+
+.instrument_list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 5em;
+    grid-row-gap: 2em;
+    margin-top: 1em;
+    width: 100%;
+}
+
+.instrument_entry {
+    display: flex;
+    margin-bottom: 1em;
+    align-items: center;
+}
+
+.entry_element {
+    display: inline;
+    min-width: 8.2em;
+}
+
+#facility-select {
+    width: 15%;
+}
+
+

--- a/src/webmon_app/reporting/static/facility_filter.js
+++ b/src/webmon_app/reporting/static/facility_filter.js
@@ -17,7 +17,7 @@ function filter_facility(selection_value) {
             item.classList.remove("visible_instrument_entry");
         });
     }
-    
+
     if (document.querySelectorAll(".visible_instrument_entry").length == 1) {
         document.querySelector(".second_column_heading").style.display = "none";
     } else {
@@ -29,5 +29,4 @@ document.querySelector("#facility-select").addEventListener("change", (event) =>
     filter_facility(event.target.value);
 });
 // Call filter_facility to handle page refreshes.
-filter_facility(document.querySelector("#facility-select").value); 
-
+filter_facility(document.querySelector("#facility-select").value);

--- a/src/webmon_app/reporting/static/facility_filter.js
+++ b/src/webmon_app/reporting/static/facility_filter.js
@@ -1,23 +1,33 @@
 // Updates the displayed table rows depending on the value of the facility select element
 function filter_facility(selection_value) {
     // "Reset" the table so that everything is shown.
-    var result_style = document.querySelectorAll('.instrument_row').forEach((item) => {
-        item.style.display = 'table-row';
+    var result_style = document.querySelectorAll(".instrument_entry").forEach((item) => {
+        item.style.display = "flex";
+        item.classList.add("visible_instrument_entry");
     });
 
     if (selection_value == "hfir") {
-        document.querySelectorAll('.SNS_instrument').forEach((item) => {
-            item.style.display = 'none';
+        document.querySelectorAll(".SNS_instrument").forEach((item) => {
+            item.style.display = "none";
+            item.classList.remove("visible_instrument_entry");
         });
     } else if (selection_value == "sns") {
-        document.querySelectorAll('.HFIR_instrument').forEach((item) => {
-            item.style.display = 'none';
+        document.querySelectorAll(".HFIR_instrument").forEach((item) => {
+            item.style.display = "none";
+            item.classList.remove("visible_instrument_entry");
         });
+    }
+    
+    if (document.querySelectorAll(".visible_instrument_entry").length == 1) {
+        document.querySelector(".second_column_heading").style.display = "none";
+    } else {
+        document.querySelector(".second_column_heading").style.display = "";
     }
 }
 // Add filter_facility as the change event listener of the facility select element
-document.querySelector("#facility-select").addEventListener('change', (event) => {
+document.querySelector("#facility-select").addEventListener("change", (event) => {
     filter_facility(event.target.value);
 });
 // Call filter_facility to handle page refreshes.
-filter_facility(document.querySelector("#facility-select").value);
+filter_facility(document.querySelector("#facility-select").value); 
+

--- a/src/webmon_app/reporting/static/live_update.js
+++ b/src/webmon_app/reporting/static/live_update.js
@@ -1,5 +1,5 @@
 function global_system_status_update(data, i){
-    var content = "<span id='"+data.instruments[i].name+"_recording_status'>"+data.instruments[i].recording_status+"</span>";
+    var content = "<span id='"+data.instruments[i].name+"_recording_status' class='entry_element'>"+data.instruments[i].recording_status+"</span>";
     $('#'+data.instruments[i].name+'_recording_status').replaceWith(content);
     return content
 }

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -79,6 +79,7 @@
     <div class="second_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3><h3 class="heading_element">Processing</h3></div>
 </div>
 <div class="instrument_list">
+    <!-- Columns are handled by CSS using a grid. -->
     {% for item in instruments %}
     <div class="{{ item.facility }}_instrument instrument_entry">
         <a href="{{ item.url|safe }}" class="entry_element">{{ item.name|upper }}</a>

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -9,6 +9,7 @@
 <script language="javascript" type="text/javascript" src="/static/thirdparty/d3.v3/d3.v3.min.js"></script>
 <script language="javascript" type="text/javascript" src="/static/bar_chart.js"></script>
 <link rel="stylesheet" media="all" href="/static/bar_chart.css" />
+<link rel="stylesheet" media="all" href="/static/dashboard.css" />
 
 <script>
   var instrument_rates = {
@@ -63,51 +64,32 @@
 </div>
 </div>
 
-<p>
-List of instruments:<br>
+<div class="dashboard_parent">
+<div class="select_menu">
+  <span>List of instruments:</span>
   <label for="facility-select">Facility:</label>
   <select name="facilities" id="facility-select">
     <option value="all">All</option>
     <option value="hfir">HFIR</option>
     <option value="sns">SNS</option>
   </select>
-  <table class="dashboard_table">
-    <!-- Left column of instruments -->
-    <td><table class="dashboard_table">
-        <!-- Column headers -->
-        <thead><tr><th style="min-width:75px">Instrument</th> <th>Status</th> <th>Processing</th></tr></thead>
-        <!-- Loop over each instrument producing one row -->
-        <tbody class='status_box'>
-        {% for item in instruments_left %}
-            <tr class='{{ item.facility }}_instrument instrument_row'>
-                <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
-                <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
-                <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table></td>
+</div>
+<div class="column_heading_parent">
+    <div class="first_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3><h3 class="heading_element">Processing</h3></div>
+    <div class="second_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3><h3 class="heading_element">Processing</h3></div>
+</div>
+<div class="instrument_list">
+    {% for item in instruments %}
+    <div class="{{ item.facility }}_instrument instrument_entry">
+        <a href="{{ item.url|safe }}" class="entry_element">{{ item.name|upper }}</a>
+        <span id="{{ item.name }}_recording_status" class="entry_element">{{ item.recording_status }}</span>
+        <div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots entry_element"></div>
+    </div>
+    {% endfor %}
+</div>
+</div>
 
-    <!-- Insert some space between left and right columns of instruments -->
-    <td style="min-width:75px"></td>
-
-    <!-- Right column of instruments -->
-    <td><table class="dashboard_table">
-        <!-- Column headers -->
-        <thead><tr><th style="min-width:75px">Instrument</th> <th>Status</th> <th>Processing</th></tr></thead>
-        <!-- Loop over each instrument producing one row -->
-        <tbody class='status_box'>
-        {% for item in instruments_right %}
-            <tr class='{{ item.facility }}_instrument instrument_row'>
-                <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
-                <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
-                <td><div id="runs_per_hour_{{ item.name|lower }}" class="dashboard_plots"></div></td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table></td>
-  </table>
-  <script language="javascript" type="text/javascript" src="/static/facility_filter.js"></script>
-  <script id="source" language="javascript" type="text/javascript">plot_rates();</script>
-  {% endblock %}
+<script language="javascript" type="text/javascript" src="/static/facility_filter.js"></script>
+<script id="source" language="javascript" type="text/javascript">plot_rates();</script>
+{% endblock %}
 {% block nocontent %}{% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
@@ -6,6 +6,7 @@
 
 {% block header %}
 <script language="javascript" type="text/javascript" src="/static/live_update.js"></script>
+<link rel="stylesheet" media="all" href="/static/dashboard_simple.css" />
 
 <script>
   function poll() {
@@ -49,48 +50,30 @@
 </div>
 </div>
 
-<p>
-List of instruments:<br>
-<label for="facility-select">Facility:</label>
-<select name="facilities" id="facility-select">
-  <option value="all">All</option>
-  <option value="hfir">HFIR</option>
-  <option value="sns">SNS</option>
-</select>
-<table class="dashboard_table"><tr>
-  <td><table class="dashboard_table">
-    <thead>
-      <tr>
-        <th style="min-width:75px">Instrument</th> <th>Status</th>
-      </tr>
-    </thead>
-    <tbody class='status_box'>
-    {% for item in instruments_left %}
-      <tr class='{{ item.facility }}_instrument instrument_row'>
-        <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
-        <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
-      </tr>
+<div class="dashboard_parent">
+<div class="select_menu">
+  <span>List of instruments:</span>
+  <label for="facility-select">Facility:</label>
+  <select name="facilities" id="facility-select">
+    <option value="all">All</option>
+    <option value="hfir">HFIR</option>
+    <option value="sns">SNS</option>
+  </select>
+</div>
+<div class="column_heading_parent">
+    <div class="first_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3></div>
+    <div class="second_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3></div>
+</div>
+<div class="instrument_list">
+    {% for item in instruments %}
+    <div class="{{ item.facility }}_instrument instrument_entry">
+        <a href="{{ item.url|safe }}" class="entry_element">{{ item.name|upper }}</a>
+        <span id="{{ item.name }}_recording_status" class="entry_element">{{ item.recording_status }}</span>
+    </div>
     {% endfor %}
-    </tbody>
-  </table></td>
-  <td style="min-width:75px"></td>
-  <td><table class="dashboard_table">
-    <thead>
-      <tr>
-        <th style="min-width:75px">Instrument</th> <th>Status</th>
-      </tr>
-    </thead>
-    <tbody class='status_box'>
-    {% for item in instruments_right %}
-      <tr class='{{ item.facility }}_instrument instrument_row'>
-        <td><a href='{{ item.url|safe }}'>{{ item.name|upper }}</a></td>
-        <td><span id='{{ item.name }}_recording_status'>{{ item.recording_status }}</span></td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table></td>
+</div>
+</div>
 
-</tr></table>
 <script language="javascript" type="text/javascript" src="/static/facility_filter.js"></script>
   {% endblock %}
 {% block nocontent %}{% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
@@ -65,6 +65,7 @@
     <div class="second_column_heading"><h3 class="heading_element">Instrument</h3><h3 class="heading_element">Status</h3></div>
 </div>
 <div class="instrument_list">
+    <!-- Columns are handled by CSS using a grid. -->
     {% for item in instruments %}
     <div class="{{ item.facility }}_instrument instrument_entry">
         <a href="{{ item.url|safe }}" class="entry_element">{{ item.name|upper }}</a>

--- a/tests/test_RunPageView.py
+++ b/tests/test_RunPageView.py
@@ -107,7 +107,7 @@ class TestRunPageView:
     def verifyDashboard(self, r):
         html = self.removeWhitespace(r.text)
 
-        self.assertHtml("""<p>List of instruments:<br>""", html)
+        self.assertHtml("""<span>List of instruments:</span>""", html)
         self.assertHtml(
             """<a href="/dasmon/dashboard/">extended dashboard</a> |
          <a href="/dasmon/summary/">latest runs</a>""",
@@ -126,7 +126,7 @@ class TestRunPageView:
         html = self.removeWhitespace(r.text)
 
         self.assertHtml("""<div id="runs_per_hour_""", html)
-        self.assertHtml("""" class="dashboard_plots"></div>""", html)
+        self.assertHtml("""class="dashboard_plots""", html)
 
     def testGeneralUserVerifyExtendedDashboard(self, extended_dashboard_general_user):
         assert extended_dashboard_general_user.status_code == 200

--- a/tests/test_extendend_dashboard.py
+++ b/tests/test_extendend_dashboard.py
@@ -8,11 +8,6 @@ class TestExtendedDashboard:
         response = request_page("/dasmon/dashboard/", settings.GENERAL_USER_USERNAME, settings.GENERAL_USER_PASSWORD)
         assert response.ok
 
-        # Check double column of instruments
-        text = HTTPText(response.text)
-        for side in ["Right", "Left"]:
-            assert f"{side} column of instruments" in text
-
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixes https://code.ornl.gov/sns-hfir-scse/infrastructure/web-monitor/-/issues/215. 

In order to allow better filtering (and just more flexible layouts in general), I did a refactoring of the html templates of the dashboards. Specifically I replaced the tables with divs, since tables really shouldn't be used for pure layout purposes. This allows filtering to work much better by taking advantage of css grids. 

Screenshots:

![filter 1](https://user-images.githubusercontent.com/30890419/181587951-6f49f1ee-be89-4f6b-9b23-e8a8cf2dfa4f.png)
![filter 2](https://user-images.githubusercontent.com/30890419/181587967-02a14af8-14c8-4583-bb5a-6e03c66fa65c.png)
![filter 3](https://user-images.githubusercontent.com/30890419/181587974-8f05c142-7e0b-4790-9a8c-6d7cf69600b5.png)
![filter 4](https://user-images.githubusercontent.com/30890419/181587991-a4f55706-4834-4e3f-ad68-16434fa70dfb.png)
![filter 5](https://user-images.githubusercontent.com/30890419/181588005-fb4a9551-0e5b-4c9e-9706-936d0fb7eb4a.png)
![filter 6](https://user-images.githubusercontent.com/30890419/181588022-31e279a3-73f1-41ac-8e93-5c52c06b573f.png)

