### PR TITLE
Increase RUN_RATE_CACHE_TIMEOUT

### DIFF
--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -276,7 +276,7 @@ CACHES = {
 }
 
 # Timeout value for cached run and error rates, in seconds
-RUN_RATE_CACHE_TIMEOUT = 120
+RUN_RATE_CACHE_TIMEOUT = 3600  # 1 hour
 # Timeout value for cached pages that are expected to be quick to render, in seconds
 FAST_PAGE_CACHE_TIMEOUT = 10
 # Timeout value for cached pages that are expected to be slow to render, in seconds

--- a/tests/test_PVPageView.py
+++ b/tests/test_PVPageView.py
@@ -29,7 +29,7 @@ def check_PV(text, PV):
         .replace("</span></td>", "")
         .replace("a.m.", "AM")
         .replace("p.m.", "PM"),
-        "%B %d, %Y, %I:%M %p",
+        "%b. %d, %Y, %I:%M %p",
     )
     time_delta = datetime.now() - time
     assert time_delta.total_seconds() < 120


### PR DESCRIPTION
The run_rate/error_rate is updated regardless of this time if a new run comes in for an instrument, see https://github.com/neutrons/data_workflow/blob/next/src/webmon_app/reporting/report/view_util.py#L244


There was also a change in the datetime format (something must have updated versions unrelated to this PR) that caused a test to fail, that test also started failing on `next`
