### PR TITLE
Trim resolution in time to miliseconds

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -714,7 +714,7 @@ def dasmon_diagnostics(instrument_id, timeout=None):
     # Recent PVs
     if time.time() - last_pv_timestamp > timeout:
         slow_pvs = True
-        dasmon_conditions.append("No PV updates in the past %s seconds" % str(time.time() - last_pv_timestamp))
+        dasmon_conditions.append("No PV updates in the past %.2f seconds" % float(time.time() - last_pv_timestamp))
 
     # Recent AMQ
     try:


### PR DESCRIPTION
The dasmon diagnostics was showing time to an exceedingly high resolution. This makes it more reasonable.