### PR TITLE
Clearer logs for error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ SNSdata.tar.gz
 src/dasmon_app/django_nscd_dasmon.egg-info/
 src/webmon_app/django_nscd_webmon.egg-info/
 src/workflow_app/django_nscd_workflow.egg-info/
+src/dasmon_app/dasmon_listener/_version.py
+src/webmon_app/reporting/_version.py
+src/workflow_app/workflow/_version.py
 
 *.o
 *.obj

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ PYTHON_VERSION:=3.10
 MANAGE_PY_WEBMON=/opt/conda/lib/python$(PYTHON_VERSION)/site-packages/reporting/manage.py
 # this is found by `find /opt/conda -name db_init.json`
 REPORT_DB_INIT=/opt/conda/lib/python$(PYTHON_VERSION)/site-packages/reporting/fixtures/db_init.json
+# command to run docker compose. change this to be what you have installed
+# this can be overriden on the command line
+# DOCKER_COMPOSE="docker compose" make startdev
+DOCKER_COMPOSE ?= docker-compose
 
 
 help:
@@ -112,7 +116,7 @@ SNSdata.tar.gz:
 
 localdev/up: ## create images and start containers for local development. Doesn't update python wheels, though.
 	\cp docker-compose.localdev.yml docker-compose.yml
-	docker-compose up --build
+	$(DOCKER_COMPOSE) up --build
 
 clean:
 	rm -f SNSdata.tar.gz

--- a/src/dasmon_app/dasmon_listener/amq_consumer.py
+++ b/src/dasmon_app/dasmon_listener/amq_consumer.py
@@ -123,8 +123,7 @@ class Listener(stomp.ConnectionListener):
         try:
             data_dict = json.loads(message)
         except:  # noqa: E722
-            logging.error("Could not decode message from %s", destination)
-            logging.error(sys.exc_info()[1])
+            logging.exception("Could not decode message from %s", destination)
             return
         # If we get a STATUS message, store it as such
         if destination.endswith(".ACK"):
@@ -140,8 +139,7 @@ class Listener(stomp.ConnectionListener):
                 # Get the instrument object
                 instrument = self.retrieve_instrument(instrument_name)
         except:  # noqa: E722
-            logging.error("Could not extract instrument name from %s", destination)
-            logging.error(str(sys.exc_info()[1]))
+            logging.exception("Could not extract instrument name from %s", destination)
             return
 
         if "STATUS" in destination:
@@ -178,8 +176,7 @@ class Listener(stomp.ConnectionListener):
                 logging.warning("SIGNAL: %s: %s", destination, str(data_dict))
                 process_signal(instrument, data_dict)
             except:  # noqa: E722
-                logging.error("Could not process signal: %s", str(data_dict))
-                logging.error(sys.exc_info()[1])
+                logging.exception("Could not process signal: %s", str(data_dict))
 
         elif "APP.SMS" in destination:
             process_SMS(instrument, headers, data_dict)
@@ -258,7 +255,7 @@ def send_message(sender, recipients, subject, message):
         s.sendmail(sender, recipients, msg.as_string())
         s.quit()
     except:  # noqa: E722
-        logging.error("Could not send message: %s", sys.exc_info()[1])
+        logging.exception("Could not send message:")
 
 
 def process_SMS(instrument_id, headers, data):
@@ -296,7 +293,7 @@ def process_SMS(instrument_id, headers, data):
                 json.dumps(status_data),
             )
     except:  # noqa: E722
-        logging.error("Could not process SMS message: %s", sys.exc_info()[1])
+        logging.exception("Could not process SMS message:")
 
 
 def process_ack(data=None, headers=None):
@@ -355,7 +352,7 @@ def process_ack(data=None, headers=None):
             if EXTRA_LOGS:
                 logging.warning("%s ACK deltas: msg=%s rcv=%s", proc_name, msg_time, answer_delay)
     except:  # noqa: E722
-        logging.error("Error processing ack: %s", sys.exc_info()[1])
+        logging.exception("Error processing ack:")
 
 
 def notify_users(instrument_id, signal):
@@ -380,7 +377,7 @@ def notify_users(instrument_id, signal):
                 message=message,
             )
     except:  # noqa: E722
-        logging.error("Failed to notify users: %s", sys.exc_info()[1])
+        logging.exception("Failed to notify users:")
 
 
 def process_signal(instrument_id, data):
@@ -493,7 +490,7 @@ def store_and_cache_(instrument_id, key_id, value, timestamp=None, cache_only=Fa
                 )
                 status_entry.timestamp = datetime_timestamp
             except:  # noqa: E722
-                logging.error("Could not process timestamp [%s]: %s", timestamp, sys.exc_info()[1])
+                logging.exception("Could not process timestamp [%s]:")
         status_entry.save()
 
     # Update the latest value
@@ -665,9 +662,9 @@ class Client:
                         else:
                             logging.error("settings.PING_TOPIC is not defined")
                 except:  # noqa: E722
-                    logging.error("Problem writing heartbeat %s", sys.exc_info()[1])
+                    logging.exception("Problem writing heartbeat")
             except:  # noqa: E722
-                logging.error("Problem connecting to AMQ broker %s", sys.exc_info()[1])
+                logging.exception("Problem connecting to AMQ broker")
                 time.sleep(5.0)
 
     def send(self, destination, message, persistent="false"):

--- a/src/webmon_app/reporting/dasmon/admin.py
+++ b/src/webmon_app/reporting/dasmon/admin.py
@@ -9,7 +9,6 @@ from reporting.dasmon.models import (
 )
 from django.contrib import admin
 import datetime
-import sys
 import logging
 
 
@@ -22,7 +21,7 @@ class StatusVariableAdmin(admin.ModelAdmin):
             try:
                 return datetime.datetime.fromtimestamp(int(obj.value))
             except:  # noqa: E722
-                logging.error(sys.exc_info()[1])
+                logging.exception("")
                 return "error"
         return "-"
 

--- a/src/webmon_app/reporting/dasmon/legacy_status.py
+++ b/src/webmon_app/reporting/dasmon/legacy_status.py
@@ -7,7 +7,6 @@
 import httplib2
 import json
 import logging
-import sys
 from reporting.dasmon.models import LegacyURL
 
 STATUS_HOST = "neutrons.ornl.gov"
@@ -49,7 +48,7 @@ def get_ops_status(instrument_id):
             organized_data.append({"group": group, "data": key_value_pairs})
         return organized_data
     except:  # noqa: E722
-        logging.warning("Could not get legacy DAS status: %s" % sys.exc_info()[1])
+        logging.warning("Could not get legacy DAS status:", exc_info=True)
         return []
 
 

--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -363,8 +363,10 @@ def get_component_status(instrument_id, red_timeout=1, yellow_timeout=None, proc
         #    STATUS_FAULT = 1
         #    STATUS_UNRESPONSIVE = 2
         #    STATUS_INACTIVE = 3
+        meaning = {0: "OK", 1: "FAULT", 2: "UNRESPONSIVE", 3: "INACTIVE"}
         if int(last_value.value) > 0:
-            logging.error("%s status = %s", process, last_value.value)
+            value = int(last_value.value)
+            logging.error("%s - %s status = %s (%d)", instrument_id, process, meaning.get(value, "UNKNOWN"), value)
             return 2
     except:  # noqa: E722
         logging.debug("No cached status for %s on instrument %s", process, instrument_id.name)

--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -2,7 +2,6 @@
 """
     Live monitoring
 """
-import sys
 import json
 import logging
 from django.http import HttpResponse
@@ -471,7 +470,7 @@ def acknowledge_signal(request, instrument, sig_id):
         sig_object = get_object_or_404(Signal, id=sig_id)
         sig_object.delete()
     except:  # noqa: E722
-        logging.error("ACK signal %s/%s: %s" % (instrument, sig_id, sys.exc_info()[1]))
+        logging.exception("ACK signal %s/%s:", instrument, sig_id)
     return HttpResponse()
 
 
@@ -530,12 +529,12 @@ def notifications(request):
                         user_options.save()
                     except:  # noqa: E722
                         alert_list.append("Could not find instrument %s" % item)
-                        logging.error("Notification registration failed: %s", sys.exc_info()[1])
+                        logging.exception("Notification registration failed:")
                 alert_list.append("Your changes have been saved.")
 
             except:  # noqa: E722
                 alert_list.append("There was a problem processing your request.")
-                logging.error("Error processing notification settings: %s", sys.exc_info()[1])
+                logging.exception("Error processing notification settings:")
         else:
             alert_list.append("Your form is invalid. Please modify your entries and re-submit.")
             logging.error("Invalid form %s", options_form.errors)

--- a/src/webmon_app/reporting/pvmon/view_util.py
+++ b/src/webmon_app/reporting/pvmon/view_util.py
@@ -5,7 +5,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2014 Oak Ridge National Laboratory
 """
-import sys
 from reporting.pvmon.models import PVName, PV, PVCache, PVStringCache
 from django.utils import dateformat, timezone
 from django.conf import settings
@@ -98,7 +97,7 @@ def get_live_variables(request, instrument_id, key_id=None):
             data_dict.append([key, data_list])
         except:  # noqa: E722
             # Could not find data for this key
-            logging.warning("Could not process %s: %s", key, str(sys.exc_info()[1]))
+            logging.warning("Could not process %s: %s", key, exc_info=True)
     return data_dict
 
 

--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -5,7 +5,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2014 Oak Ridge National Laboratory
 """
-import sys
 import re
 import logging
 from django import forms
@@ -29,11 +28,7 @@ def _get_choices(instrument):
         for item in choices:
             form_choices.append((item.value, item.description))
     except:  # noqa: E722
-        logging.error(
-            "_get_choices: %s instrument or grouping does not exist\n %s",
-            instrument.upper(),
-            sys.exc_info()[1],
-        )
+        logging.exception("_get_choices: %s instrument or grouping does not exist", instrument.upper())
     return sorted(form_choices, key=lambda x: x[1])
 
 
@@ -104,7 +99,7 @@ class BaseReductionConfigurationForm(forms.Form):
                     value = ""
                 reporting.reduction.view_util.store_property(instrument_id, key, value, user=user)
             except:  # noqa: E722
-                logging.error("BaseReductionConfigurationForm.to_db: %s", sys.exc_info()[1])
+                logging.exception("BaseReductionConfigurationForm.to_db:")
 
     def to_template(self):
         """
@@ -374,7 +369,7 @@ class MaskForm(forms.Form):
                     for item in mask_strings:
                         mask_list.append(eval(item.lower()))
         except:  # noqa: E722
-            logging.error("MaskForm count not parse a command line: %s", sys.exc_info()[1])
+            logging.exception("MaskForm count not parse a command line:")
         return mask_list
 
     @classmethod

--- a/src/webmon_app/reporting/reduction/views.py
+++ b/src/webmon_app/reporting/reduction/views.py
@@ -5,7 +5,6 @@
     @copyright: 2014 Oak Ridge National Laboratory
 """
 
-import sys
 import logging
 import json
 import datetime
@@ -121,7 +120,7 @@ def configuration_ref_m(request, instrument):
                 view_util.send_template_request(instrument_id, options_form.to_template(), user=request.user)
                 return redirect(reverse("reduction:configuration", args=[instrument]))
             except:  # noqa: E722
-                logging.error("Error sending AMQ script request: %s", sys.exc_info()[1])
+                logging.exception("Error sending AMQ script request:")
                 error_msg.append("Error processing request")
         else:
             logging.error("Invalid form %s", options_form.errors)
@@ -206,7 +205,7 @@ def configuration_cncs(request, instrument):
                 view_util.send_template_request(instrument_id, options_form.to_template(), user=request.user)
                 return redirect(reverse("reduction:configuration", args=[instrument]))
             except:  # noqa: E722
-                logging.error("Error sending AMQ script request: %s", sys.exc_info()[1])
+                logging.exception("Error sending AMQ script request:")
                 error_msg.append("Error processing request")
         else:
             logging.error("Invalid form %s %s", options_form.errors, mask_form.errors)
@@ -299,7 +298,7 @@ def configuration_dgs(request, instrument):
                 view_util.send_template_request(instrument_id, options_form.to_template(), user=request.user)
                 return redirect(reverse("reduction:configuration", args=[instrument]))
             except:  # noqa: E722
-                logging.error("Error sending AMQ script request: %s", sys.exc_info()[1])
+                logging.exception("Error sending AMQ script request:")
                 error_msg.append("Error processing request")
         else:
             logging.error("Invalid form %s %s", options_form.errors, mask_form.errors)
@@ -403,7 +402,7 @@ def configuration_corelli(request, instrument):
                 view_util.send_template_request(instrument_id, options_form.to_template(), user=request.user)
                 return redirect(reverse("reduction:configuration", args=[instrument]))
             except:  # noqa: E722
-                logging.error("Error sending AMQ script request: %s", sys.exc_info()[1])
+                logging.exception("Error sending AMQ script request:")
                 error_msg.append("Error processing request")
         else:
             logging.error("Invalid form %s %s", options_form.errors, mask_form.errors)
@@ -419,12 +418,12 @@ def configuration_corelli(request, instrument):
             try:
                 mask_list = forms.MaskForm.from_dict_list(params_dict["mask"])
             except:  # noqa: E722
-                logging.error("Error evaluating the mask information: %s", sys.exc_info()[1])
+                logging.exception("Error evaluating the mask information:")
         if "plot_requests" in params_dict:
             try:
                 plot_list = forms.PlottingForm.from_dict_list(params_dict["plot_requests"])
             except:  # noqa: E722
-                logging.error("Error evaluating the plotting information: %s", sys.exc_info()[1])
+                logging.exception("Error evaluating the plotting information:")
         mask_form = MaskFormSet(initial=mask_list)
         plot_form = PlotFormSet(initial=plot_list)
 
@@ -478,19 +477,19 @@ def configuration_change(request, instrument):
                 template_dict[item["key"]] = item["value"]
                 view_util.store_property(instrument_id, item["key"], item["value"], user=request.user)
             except:  # noqa: E722
-                logging.error("config_change: %s", sys.exc_info()[1])
+                logging.exception("config_change:")
 
         # Check whether the user wants to install the default script
         if "use_default" in request.POST:
             try:
                 template_dict["use_default"] = int(request.POST["use_default"]) == 1
             except:  # noqa: E722
-                logging.error("Error parsing use_default parameter: %s", sys.exc_info()[1])
+                logging.exception("Error parsing use_default parameter:")
         # Send ActiveMQ request
         try:
             view_util.send_template_request(instrument_id, template_dict, user=request.user)
         except:  # noqa: E722
-            logging.error("Error sending AMQ script request: %s", sys.exc_info()[1])
+            logging.exception("Error sending AMQ script request:")
             return HttpResponse("Error processing request", status=500)
 
     data_dict = {}

--- a/src/webmon_app/reporting/report/catalog.py
+++ b/src/webmon_app/reporting/report/catalog.py
@@ -6,7 +6,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2018 Oak Ridge National Laboratory
 """
-import sys
 import logging
 
 try:
@@ -34,7 +33,7 @@ def decode_time(timestamp):
                 date_time_str = date_time_str[:sec_location]
             return datetime.datetime.strptime(date_time_str, "%Y-%m-%dT%H:%M:%S")
     except:  # noqa: E722
-        logging.error("Could not parse timestamp '%s': %s", timestamp, sys.exc_info()[1])
+        logging.exception("Could not parse timestamp '%s':", timestamp)
         return None
 
 
@@ -110,6 +109,6 @@ def _get_run_info(instrument, ipts, run_number, facility="SNS"):
                 run_info["startTime"] = decode_time(datafile.metadata.get("entry", {}).get("start_time", None))
                 run_info["endTime"] = decode_time(datafile.metadata.get("entry", {}).get("end_time", None))
     except:  # noqa: E722
-        logging.error("Communication with ONCat server failed: %s", sys.exc_info()[1])
+        logging.exception("Communication with ONCat server failed:")
 
     return run_info

--- a/src/webmon_app/reporting/report/forms.py
+++ b/src/webmon_app/reporting/report/forms.py
@@ -5,7 +5,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2016 Oak Ridge National Laboratory
 """
-import sys
 from django import forms
 from django.core.exceptions import ValidationError
 from django.conf import settings
@@ -29,7 +28,7 @@ def validate_integer_list(value):
                 try:
                     value_list.extend(range(int(range_toks[0]), int(range_toks[1]) + 1))
                 except:  # noqa: E722
-                    logging.error(sys.exc_info()[1])
+                    logging.exception("")
                     raise ValidationError("Error parsing %s for a range of integers" % value)
             else:
                 logging.error("Found more than two tokens around -")
@@ -39,7 +38,7 @@ def validate_integer_list(value):
             try:
                 value_list.append(int(item))
             except:  # noqa: E722
-                logging.error(sys.exc_info()[1])
+                logging.exception("")
                 raise ValidationError("Error parsing %s for a range of integers" % value)
 
     return value_list
@@ -217,7 +216,7 @@ class ProcessingForm(forms.Form):
         try:
             queue = StatusQueue.objects.get(name=self.cleaned_data["task"])
         except StatusQueue.DoesNotExist:
-            logging.error(sys.exc_info()[1])
+            logging.exception("")
 
         # Returns a report and task to be sent
         return {

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -4,7 +4,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2014 Oak Ridge National Laboratory
 """
-import sys
 import logging
 import json
 import datetime
@@ -124,7 +123,7 @@ def needs_reduction(request, run_id):
     try:
         red_queue = StatusQueue.objects.get(name="REDUCTION.DATA_READY")
     except StatusQueue.DoesNotExist:
-        logging.error(sys.exc_info()[1])
+        logging.exception("")
         return False
 
     # Check whether we have a task for this queue
@@ -214,7 +213,7 @@ def processing_request(request, instrument, run_id, destination):
             send_processing_request(instrument_id, run_object, request.user, destination=destination)
         except:  # noqa: E722
             logging.error("Could not send post-processing request: %s", destination)
-            logging.error(sys.exc_info()[1])
+            logging.exception("")
             return HttpResponseServerError()
     # return render(request, 'report/processing_request_failure.html', {})
     return redirect(reverse("report:detail", args=[instrument, run_id]))
@@ -282,7 +281,7 @@ def run_rate(instrument_id, n_hours=24):
         return [[int(r[0]), int(r[1])] for r in rows]
     except:  # noqa: E722
         connection.close()
-        logging.error("Run rate (%s): %s", str(instrument_id), sys.exc_info()[1])
+        logging.exception("Run rate (%s):", str(instrument_id))
 
         # Do it by hand (slow)
         time = timezone.now()
@@ -316,7 +315,7 @@ def error_rate(instrument_id, n_hours=24):
         return [[int(r[0]), int(r[1])] for r in rows]
     except:  # noqa: E722
         connection.close()
-        logging.error("Error rate (%s): %s", str(instrument_id), sys.exc_info()[1])
+        logging.exception("Error rate (%s):", str(instrument_id))
 
         # Do it by hand (slow)
         time = timezone.now()
@@ -416,7 +415,7 @@ def get_run_status_text(run_id, show_error=False, use_element_id=False):
             else:
                 status = "<span %s class='red'>incomplete</span>" % element_id
     except:  # noqa: E722
-        logging.error("report.view_util.get_run_status_text: %s", sys.exc_info()[1])
+        logging.exception("report.view_util.get_run_status_text:")
     return status
 
 
@@ -451,7 +450,7 @@ def get_run_list_dict(run_list):
                 }
             )
     except:  # noqa: E722
-        logging.error("report.view_util.get_run_list_dict: %s", sys.exc_info()[1])
+        logging.exception("report.view_util.get_run_list_dict:")
     return run_dicts
 
 
@@ -491,7 +490,7 @@ def extract_ascii_from_div(html_data, trace_id=None):
                 return ascii_data
     except:  # noqa: E722
         # Unable to extract data from <div>
-        logging.debug("Unable to extract data from <div>: %s", sys.exc_info()[1])
+        logging.debug("Unable to extract data from <div>:", exc_info=True)
     return None
 
 
@@ -565,7 +564,7 @@ def get_plot_data_from_server(instrument, run_id, data_type="json"):
         if data_request.status == 200:
             json_data = data_request.read()
     except:  # noqa: E722
-        logging.error("Could not pull data from live data server:\n%s", sys.exc_info()[1])
+        logging.exception("Could not pull data from live data server:")
     return json_data
 
 
@@ -615,7 +614,7 @@ def extract_d3_data_from_json(json_data):
                 else:
                     plot_data = [[x_values[i], y_values[i], e_values[i]] for i in range(len(y_values))]
     except:  # noqa: E722
-        logging.error("Error finding reduced json data: %s", sys.exc_info()[1])
+        logging.exception("Error finding reduced json data:")
     return plot_data, x_label, y_label
 
 
@@ -638,5 +637,5 @@ def find_skipped_runs(instrument_id, start_run_number=0):
             if len(query_set) == 0:
                 missing_runs.append(i)
     except:  # noqa: E722
-        logging.error("Error finding missing runs: %s", sys.exc_info()[1])
+        logging.exception("Error finding missing runs:")
     return missing_runs

--- a/src/webmon_app/reporting/report/views.py
+++ b/src/webmon_app/reporting/report/views.py
@@ -75,7 +75,7 @@ def processing_admin(request):
                             str(run_obj.run_number),
                             sys.exc_info()[1],
                         )
-                        logging.error(sys.exc_info()[1])
+                        logging.exception("")
                 template_values["notes"] += submission_errors
                 if len(submission_errors) == 0:
                     template_values["notes"] += "<b>All tasks were submitted</b><br>"
@@ -279,7 +279,7 @@ def detail(request, instrument, run_id):
                 template_values["no_icat_info"] = "The final data file for this run is not yet available."
 
     except:  # noqa: E722
-        logging.error("Could not determine whether we have catalog info: %s", sys.exc_info()[1])
+        logging.exception("Could not determine whether we have catalog info:")
         template_values["no_icat_info"] = "There is no catalog information for this run yet."
     template_values = users_view_util.fill_template_values(request, **template_values)
     template_values = dasmon_view_util.fill_template_values(request, **template_values)

--- a/src/webmon_app/reporting/reporting_app/view_util.py
+++ b/src/webmon_app/reporting/reporting_app/view_util.py
@@ -3,7 +3,6 @@
 
     @copyright: 2014 Oak Ridge National Laboratory
 """
-import sys
 from django.conf import settings
 import logging
 
@@ -37,5 +36,5 @@ def reduction_setup_url(instrument):
 
             return reporting.reduction.view_util.reduction_setup_url(instrument)
     except:  # noqa: E722
-        logging.error("Error getting reduction setup url: %s", sys.exc_info()[1])
+        logging.exception("Error getting reduction setup url:")
     return None

--- a/src/webmon_app/reporting/users/admin.py
+++ b/src/webmon_app/reporting/users/admin.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 import socket
 from django.conf import settings  # noqa: F401
 import logging
-import sys
 
 
 class NonDeveloperUsers(admin.SimpleListFilter):
@@ -37,7 +36,7 @@ class NonDeveloperUsers(admin.SimpleListFilter):
                 nodes = DeveloperNode.objects.all().values_list("ip", flat=True)
                 return queryset.exclude(user__is_staff=True).exclude(ip__in=nodes)
             except:  # noqa: E722
-                logging.error(sys.exc_info()[1])
+                logging.exception("")
 
         return queryset
 

--- a/src/webmon_app/reporting/users/view_util.py
+++ b/src/webmon_app/reporting/users/view_util.py
@@ -2,7 +2,6 @@
 """
     View utility functions for user management
 """
-import sys
 from django.urls import reverse
 from django.shortcuts import redirect
 from django.contrib.auth.models import Group
@@ -118,7 +117,7 @@ def login_or_local_required_401(fn):
                 return fn(request, *args, **kws)
             return HttpResponse(status=401)
         except:  # noqa: E722
-            logging.error("[%s]: %s", request.path, sys.exc_info()[1])
+            logging.exception("[%s]:", request.path)
             return HttpResponse(status=500)
 
     return request_processor

--- a/src/workflow_app/workflow/amq_client.py
+++ b/src/workflow_app/workflow/amq_client.py
@@ -5,7 +5,6 @@
     @author: M. Doucet, Oak Ridge National Laboratory
     @copyright: 2014 Oak Ridge National Laboratory
 """
-import sys
 import time
 import stomp
 import logging
@@ -159,7 +158,7 @@ class Client:
                     allowed_lag=self._workflow_check_delay,
                 ).verify_workflow()
             except:  # noqa: E722
-                logging.error("Workflow verification failed: %s", sys.exc_info()[1])
+                logging.exception("Workflow verification failed:")
 
     def listen_and_wait(self, waiting_period=1.0):
         """
@@ -173,7 +172,7 @@ class Client:
             self.connect()
             self.verify_workflow()
         except:  # noqa: E722
-            logging.error("Problem starting AMQ client: %s", sys.exc_info()[1])
+            logging.exception("Problem starting AMQ client:")
 
         last_heartbeat = 0
         while True:
@@ -198,12 +197,12 @@ class Client:
                             persistent="false",
                         )
                 except:  # noqa: E722
-                    logging.error("Problem sending heartbeat: %s", sys.exc_info()[1])
+                    logging.exception("Problem sending heartbeat:")
 
                 # Check for workflow completion
                 if time.time() - self._workflow_check_start > self._workflow_check_delay:
                     self.verify_workflow()
                     self._workflow_check_start = time.time()
             except:  # noqa: E722
-                logging.error("Problem connecting to AMQ broker: %s", sys.exc_info()[1])
+                logging.exception("Problem connecting to AMQ broker:")
                 time.sleep(5.0)

--- a/src/workflow_app/workflow/amq_listener.py
+++ b/src/workflow_app/workflow/amq_listener.py
@@ -2,7 +2,6 @@
 """
     ActiveMQ listener class for the workflow manager
 """
-import sys
 import stomp
 import logging
 from . import states
@@ -61,7 +60,7 @@ class Listener(stomp.ConnectionListener):
             action = states.StateAction(connection=connection, use_db_task=self._use_db_tasks)
             action(headers, message)
         except:  # noqa: E722
-            logging.error("Listener failed to process message: %s", str(sys.exc_info()[1]))
+            logging.exception("Listener failed to process message:")
             logging.error("  Message: %s: %s", headers["destination"], str(message))
         if not self._auto_ack:
             connection.ack(headers["message-id"], headers["subscription"])

--- a/src/workflow_app/workflow/database/transactions.py
+++ b/src/workflow_app/workflow/database/transactions.py
@@ -2,11 +2,9 @@
 """
     Perform DB transactions
 """
-import sys
 import os
 import json
 import logging
-import traceback
 
 # The workflow modules must be on the python path
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "workflow.database.settings")
@@ -86,8 +84,7 @@ def add_status_entry(headers, data):
             ipts_id.instruments.add(instrument_id)
             ipts_id.save()
     except:  # noqa: E722
-        traceback.print_exc()
-        logging.error(sys.exc_info()[1])
+        logging.exception("")
 
     # Check whether we already have an entry for this run
     run_number = int(data_dict["run_number"])
@@ -174,7 +171,7 @@ def get_task(message_headers, message_data):
     try:
         data_dict = json.loads(message_data)
     except:  # noqa: E722
-        logging.error("transactions.get_task expects JSON-encoded message: %s", sys.exc_info()[1])
+        logging.exception("transactions.get_task expects JSON-encoded message:")
         return None
 
     # Look for instrument

--- a/src/workflow_app/workflow/states.py
+++ b/src/workflow_app/workflow/states.py
@@ -10,7 +10,6 @@ from .settings import REDUCTION_DATA_READY, REDUCTION_CATALOG_DATA_READY
 from .database import transactions
 import json
 import logging
-import sys
 
 
 class StateAction:
@@ -62,7 +61,7 @@ class StateAction:
                 exec("from %s import %s as action_cls" % (module, cls))
                 action_cls(connection=self._send_connection)(headers, message)  # noqa: F821
             except:  # noqa: E722
-                logging.error("Task [%s] failed: %s" % (headers["destination"], sys.exc_info()[1]))
+                logging.exception("Task [%s] failed:", headers["destination"])
         if "task_queues" in task_def:
             for item in task_def["task_queues"]:
                 destination = "/queue/%s" % item


### PR DESCRIPTION
Add the instrument name and a friendly name of the error enum then I got a little out of hand.

I changed all of the "old style" logging of exception stacktraces to use `logging.exception` instead because the stacktrace is built in. Also added in a custom logger with the name `LOGNAME = "dasmon:view_util"` for the dasmon `view_utils.py` which could be expanded out to other files.