### PR TITLE
Tighten dashboard layouts

### DIFF
--- a/src/webmon_app/reporting/static/dashboard.css
+++ b/src/webmon_app/reporting/static/dashboard.css
@@ -15,7 +15,7 @@
 .column_heading_parent {
     display: grid;
     width: 100%;
-    grid-column-gap: 5em;
+    grid-column-gap: 2em;
 }
 
 .first_column_heading {
@@ -46,7 +46,7 @@
 .instrument_list {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
-    grid-column-gap: 5em;
+    grid-column-gap: 2em;
     margin-top: 1em;
     width: 100%;
 }
@@ -59,7 +59,7 @@
 
 .entry_element {
     display: inline;
-    min-width: 8.2em;
+    min-width: 5.2em;
 }
 
 #facility-select {

--- a/src/webmon_app/reporting/static/dashboard_simple.css
+++ b/src/webmon_app/reporting/static/dashboard_simple.css
@@ -14,6 +14,7 @@
 
 .column_heading_parent {
     display: grid;
+    grid-template-columns: 1fr 2fr;
     width: 100%;
     grid-column-gap: 5em;
 }
@@ -43,7 +44,7 @@
 
 .instrument_list {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr 2fr;
     grid-column-gap: 5em;
     grid-row-gap: 2em;
     margin-top: 1em;


### PR DESCRIPTION
This adjusts the spacing in the instrument list to hopefully improve the appearance

Fixes: will add a link when code.ornl.gov is back

Dashboard before:
![dashboard_before](https://user-images.githubusercontent.com/5595210/184954589-70d1604a-9551-4ab0-8518-96cf484230c7.png)
Dashboard after:
![dashboard_after](https://user-images.githubusercontent.com/5595210/184954585-8dd1cee6-5215-4bb1-bb03-3545660a2089.png)

Extended dashboard before:
![extended_before](https://user-images.githubusercontent.com/5595210/184954593-28f62076-8600-44ea-9bff-facf92278000.png)
Extended dashboard after:
![extended_after](https://user-images.githubusercontent.com/5595210/184954592-7f91f003-c766-4792-8972-44ec7d7ac4e6.png)
