### PR TITLE
Fix Data download link

### DIFF
--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -463,9 +463,12 @@ def extract_ascii_from_div(html_data, trace_id=None):
 
     #TODO: allow to specify which trace to return in cases where we have multiple curves
     """
+    if isinstance(html_data, bytes):
+        html_data = html_data.decode()
+
     try:
-        result = re.search(r"newPlot\((.*)\)</script>", html_data)
-        jsondata_str = "[%s]" % result.group(1)
+        result = re.search(r"newPlot\((.*)\).*</script>", html_data, re.DOTALL)
+        jsondata_str = "[%s]" % result.group(1).replace("'", '"')
         data_list = json.loads(jsondata_str)
         ascii_data = ""
         for d in data_list:


### PR DESCRIPTION
This is a bug from the python 2 to 3 conversion. You should now see the "download plot data points" link when you have a single 1D plot.

The `html_data` input to the `extract_ascii_from_div` function is the results of `curl https://livedata.sns.gov/plots/pg3/53956/update/html/`.

Fixes https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/450

![2022-08-31-131342_850x706_scrot](https://user-images.githubusercontent.com/5595210/187763858-b87858d9-9a2c-499d-be78-4b94f54397d8.png)
![2022-08-31-131337_850x706_scrot](https://user-images.githubusercontent.com/5595210/187763860-5e8695af-ba7a-441d-80f1-4b4d09003017.png)
![2022-08-31-131335_850x706_scrot](https://user-images.githubusercontent.com/5595210/187763861-ba450134-7f1b-44d9-b225-4afc032afd1a.png)
