### PR TITLE
Replace ActiveMQ docker image with security vulnerabilities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,12 +100,12 @@ services:
       retries: 5
 
   activemq:
-    image: rmohr/activemq
+    image: apache/activemq-classic
     hostname: activemq
     volumes:
-      - ./src/workflow_app/workflow/icat_activemq.xml:/opt/activemq/conf/activemq.xml
+      - ./src/workflow_app/workflow/icat_activemq.xml:/opt/apache-activemq/conf/activemq.xml
     healthcheck:
-      test: "curl --silent --show-error -u admin:admin 'http://localhost:8161/api/jolokia/read/org.apache.activemq:type=Broker,brokerName=localhost,service=Health' | grep --silent -e 'Good' -e 'Getting Worried'"
+      test: "curl --silent --show-error -u admin:admin -H 'Origin:http://localhost' 'http://localhost:8161/api/jolokia/read/org.apache.activemq:type=Broker,brokerName=localhost,service=Health' | grep --silent -e 'Good' -e 'Getting Worried'"
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
# Short description of the changes:
When deploying WebMon to the test environment Randy got a security exception in the ActiveMQ broker deployment, due to the dependency log4j1.2.17. "the security scan is saying we need log4j 2.16 or later"

This change replaces the ActiveMQ broker docker image from the archived repo https://github.com/rmohr/docker-activemq with an official ActiveMQ docker image from Apache: https://hub.docker.com/r/apache/activemq-classic.

The new broker uses a log4j version > 2.16:
```
# find / -type f -name log4*
/opt/apache-activemq/lib/optional/log4j-slf4j2-impl-2.22.0.jar
/opt/apache-activemq/lib/optional/log4j-core-2.22.0.jar
/opt/apache-activemq/lib/optional/log4j-api-2.22.0.jar
/opt/apache-activemq/examples/openwire/advanced-scenarios/jms-example-queue/src/main/resources/log4j2.properties
/opt/apache-activemq/examples/openwire/advanced-scenarios/jms-example-topic/src/main/resources/log4j2.properties
/opt/apache-activemq/examples/conf/log4j2.properties
/opt/apache-activemq/conf/log4j2.properties
```

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# References
[Defect 3940: Replace ActiveMQ docker image](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3940)
