### PR TITLE
Fix error thrown when the task_class of a task is None

### DIFF
--- a/src/workflow_app/workflow/states.py
+++ b/src/workflow_app/workflow/states.py
@@ -53,7 +53,7 @@ class StateAction:
         :param message: JSON-encoded message content
         """
         task_def = json.loads(task_data)
-        if "task_class" in task_def and len(task_def["task_class"].strip()) > 0:
+        if "task_class" in task_def and (task_def["task_class"] is not None) and len(task_def["task_class"].strip()) > 0:
             try:
                 toks = task_def["task_class"].strip().split(".")
                 module = ".".join(toks[: len(toks) - 1])

--- a/src/workflow_app/workflow/states.py
+++ b/src/workflow_app/workflow/states.py
@@ -53,7 +53,11 @@ class StateAction:
         :param message: JSON-encoded message content
         """
         task_def = json.loads(task_data)
-        if "task_class" in task_def and (task_def["task_class"] is not None) and len(task_def["task_class"].strip()) > 0:
+        if (
+            "task_class" in task_def
+            and (task_def["task_class"] is not None)
+            and len(task_def["task_class"].strip()) > 0
+        ):
             try:
                 toks = task_def["task_class"].strip().split(".")
                 module = ".".join(toks[: len(toks) - 1])


### PR DESCRIPTION
# Short description of the changes:
Tasks added using the Django admin interface will have `task_class` equal to `None` if it is left empty. A task with `task_class` equal to `None` caused an error to be thrown in `workflow_app` in the WebMon test environment. This PR adds a check for `None` before the call to `strip()` and a unit test.

```
INFO:2024-02-27 14:52:37,039 arcs r201562: POSTPROCESS.DATA_READY: {'facility': 'SNS', 'instrument': 'arcs', 'ipts': 'IPTS-27800', 'run_number': 201562, 'data_file': '/SNS/ARCS/IPTS-27800/nexus/ARCS_201562.nxs.h5', 'information': 'Requested by u5z'}
ERROR:2024-02-27 14:52:37,061 Listener failed to process message:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/workflow/amq_listener.py", line 61, in on_message
    action(headers, message)
  File "/opt/conda/lib/python3.10/site-packages/workflow/state_utilities.py", line 70, in process_function
    return action(self, headers, message)
  File "/opt/conda/lib/python3.10/site-packages/workflow/states.py", line 84, in __call__
    self._call_db_task(task_data, headers, message)
  File "/opt/conda/lib/python3.10/site-packages/workflow/states.py", line 56, in _call_db_task
    if "task_class" in task_def and len(task_def["task_class"].strip()) > 0:
AttributeError: 'NoneType' object has no attribute 'strip'
```


# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Story 2822: Test post processing agent v3.0 in test environment](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2822)