### PR TITLE
Make list of HFIR instruments complete

### DIFF
--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -334,7 +334,24 @@ LIVE_DATA_SERVER_PORT = "443"
 # set up the mapping of instruments to facilities
 FACILITY_INFO = defaultdict(lambda: "SNS")  # SNS is the default
 # add hfir instruments
-for instr in ["hb2c", "cg1d", "hb2a", "hb2b", "hb3a", "cg2", "cg3"]:
+for instr in (
+    "cg1a",
+    "cg1b",
+    "cg1d",
+    "cg2",
+    "cg3",
+    "cg4b",
+    "cg4c",
+    "cg4d",
+    "hb1",
+    "hb1a",
+    "hb2a",
+    "hb2b",
+    "hb2c",
+    "hb2d",
+    "hb3",
+    "hb3a",
+):
     FACILITY_INFO[instr] = "HFIR"
 # read in additional values/overrides from the environment
 facility_info_additions = environ.get("FACILITY_INFO", "").strip()


### PR DESCRIPTION
The filter on the instrument status page should now include all HFIR instruments.

![hfir_filter](https://github.com/neutrons/data_workflow/assets/5595210/1427f598-e25e-4b59-a492-a963fa785d52)

[EWM2710](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2710)

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
