### PR TITLE
Configurable Live Data Server domain name

### DIFF
--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -328,8 +328,8 @@ HELPLINE_EMAIL = "adara_support@ornl.gov"
 INSTRUMENT_REDUCTION_SETUP = ("seq", "arcs", "corelli", "cncs", "ref_m")
 
 LIVE_DATA_SERVER = "/plots/$instrument/$run_number/update"
-LIVE_DATA_SERVER_DOMAIN = "livedata.sns.gov"
-LIVE_DATA_SERVER_PORT = "443"
+LIVE_DATA_SERVER_DOMAIN = environ.get("LIVE_DATA_SERVER_DOMAIN", "livedata.sns.gov")
+LIVE_DATA_SERVER_PORT = environ.get("LIVE_DATA_SERVER_PORT", "443")
 
 # set up the mapping of instruments to facilities
 FACILITY_INFO = defaultdict(lambda: "SNS")  # SNS is the default


### PR DESCRIPTION
# Short description of the changes:
Allow the user to override the Live Data Server domain name and port using environment variables. This is to be able to test the new RHEL9 Live Data Server under its temporary domain name.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
[Story 4767: [LiveDataServer] Deploy containerized Live Data Server and test with WebMon test environment](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4767)
[Task 4885: Fix hardcoded "livedata.sns.gov" in WebMon](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4885)