### PR TITLE
Update Django model dasmon_statusvariable id field to bigint

### DIFF
--- a/src/webmon_app/reporting/dasmon/models.py
+++ b/src/webmon_app/reporting/dasmon/models.py
@@ -25,6 +25,7 @@ class StatusVariable(models.Model):
     Table containing key-value pairs from the DASMON
     """
 
+    id = models.BigAutoField(primary_key=True)
     instrument_id = models.ForeignKey(Instrument, on_delete=models.CASCADE)
     key_id = models.ForeignKey(Parameter, on_delete=models.CASCADE)
     value = models.CharField(max_length=128)


### PR DESCRIPTION
# Short description of the changes:
Dasmon listener was not able to store updates from Dasmon because the table dasmon_statusvariable id field became out of range. The issue was fixed temporarily by making the integer type larger in the production database:

```
ALTER TABLE dasmon_statusvariable ALTER COLUMN id TYPE BIGINT;
```

This changes the maximum ID's from 2147483647 to 9223372036854775807. See https://docs.djangoproject.com/en/3.2/ref/models/fields/#bigautofield

This PR is to make that change to the Django model as well so that the next time migrations are run on the database the Django model and database table definition are consistent.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Defect 5742](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5742) 
