### PR TITLE
REF_M: Add the capability to autoreduce two samples from the same run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,11 @@ repos:
       - id: end-of-file-fixer
       - id: sort-simple-yaml
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: ['--line-length=119']
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     - id: flake8

--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -300,42 +300,90 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     """
     Generic form for REF_M reduction instruments
     """
-
-    use_sangle = forms.BooleanField(required=False, initial=True)
-    use_const_q = forms.BooleanField(required=False, initial=False)
-    use_roi_bck = forms.BooleanField(required=False, initial=False)
-    const_q_cutoff = forms.FloatField(required=False, initial=0.02)
-    use_side_bck = forms.BooleanField(required=False, initial=False)
-    bck_width = forms.IntegerField(required=True, initial=10)
-    fit_peak_in_roi = forms.BooleanField(required=False, initial=False)
-    force_peak = forms.BooleanField(required=False, initial=False)
-    plot_in_2D = forms.BooleanField(required=False, initial=False)
-    peak_min = forms.IntegerField(required=True, initial=160)
-    peak_max = forms.IntegerField(required=True, initial=170)
-    force_background = forms.BooleanField(required=False, initial=False)
-    bck_min = forms.IntegerField(required=True, initial=5)
-    bck_max = forms.IntegerField(required=True, initial=100)
     skip_quicknxs = forms.BooleanField(required=False, initial=False)
-    q_step = forms.FloatField(required=False, initial=-0.02)
 
-    # List of field that are used in the template
+    # Options for all samples in the run
+    plot_in_2D = forms.BooleanField(required=False, initial=False)
+    use_const_q = forms.BooleanField(required=False, initial=False)
+    const_q_cutoff = forms.FloatField(required=False, initial=0.02)
+    q_step = forms.FloatField(required=False, initial=-0.02)
+    use_sangle = forms.BooleanField(required=False, initial=True)
+    fit_peak_in_roi = forms.BooleanField(required=False, initial=False)
+    sample_count = forms.IntegerField(required=True, min_value=1, initial=1, widget=forms.NumberInput(attrs={'size': '2'}))
+
+    # Options for first sample
+    force_peak = forms.BooleanField(required=False, initial=False)
+    peak_min = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_max = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_roi_bck = forms.BooleanField(required=False, initial=False)
+    force_background = forms.BooleanField(required=False, initial=False)
+    bck_min = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_max = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_side_bck = forms.BooleanField(required=False, initial=False)
+    bck_width = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+
+    # Options for second sample
+    force_peak_s2 = forms.BooleanField(required=False, initial=False)
+    peak_min_s2 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_max_s2 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_roi_bck_s2 = forms.BooleanField(required=False, initial=False)
+    force_background_s2 = forms.BooleanField(required=False, initial=False)
+    bck_min_s2 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_max_s2 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_side_bck_s2 = forms.BooleanField(required=False, initial=False)
+    bck_width_s2 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+
+    # Options for third sample
+    force_peak_s3 = forms.BooleanField(required=False, initial=False)
+    peak_min_s3 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_max_s3 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_roi_bck_s3 = forms.BooleanField(required=False, initial=False)
+    force_background_s3 = forms.BooleanField(required=False, initial=False)
+    bck_min_s3 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_max_s3 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    use_side_bck_s3 = forms.BooleanField(required=False, initial=False)
+    bck_width_s3 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+
+    # List of fields are used in the template
     _template_list = [
-        "use_sangle",
+        # Options for all samples in the run
+        "plot_in_2D",
         "use_const_q",
         "const_q_cutoff",
+        "q_step",
+        "use_sangle",
         "fit_peak_in_roi",
-        "plot_in_2D",
+        "sample_count",
+        # Options for first sample
         "force_peak",
         "peak_min",
         "peak_max",
-        "q_step",
+        "use_roi_bck",
         "force_background",
         "bck_min",
         "bck_max",
-        "use_roi_bck",
         "use_side_bck",
         "bck_width",
-        "skip_quicknxs",
+        # Options for second sample
+        "force_peak_s2",
+        "peak_min_s2",
+        "peak_max_s2",
+        "use_roi_bck_s2",
+        "force_background_s2",
+        "bck_min_s2",
+        "bck_max_s2",
+        "use_side_bck_s2",
+        "bck_width_s2",
+        # Options for third sample
+        "force_peak_s3",
+        "peak_min_s3",
+        "peak_max_s3",
+        "use_roi_bck_s3",
+        "force_background_s3",
+        "bck_min_s3",
+        "bck_max_s3",
+        "use_side_bck_s3",
+        "bck_width_s3",
     ]
 
 

--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -300,6 +300,7 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     """
     Generic form for REF_M reduction instruments
     """
+
     skip_quicknxs = forms.BooleanField(required=False, initial=False)
 
     # Options for all samples in the run
@@ -309,40 +310,42 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     q_step = forms.FloatField(required=False, initial=-0.02)
     use_sangle = forms.BooleanField(required=False, initial=True)
     fit_peak_in_roi = forms.BooleanField(required=False, initial=False)
-    sample_count = forms.IntegerField(required=True, min_value=1, initial=1, widget=forms.NumberInput(attrs={'size': '2'}))
+    sample_count = forms.IntegerField(
+        required=True, min_value=1, initial=1, widget=forms.NumberInput(attrs={"size": "2"})
+    )
 
     # Options for first sample
     force_peak = forms.BooleanField(required=False, initial=False)
-    peak_min = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
-    peak_max = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_min = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
+    peak_max = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
     use_roi_bck = forms.BooleanField(required=False, initial=False)
     force_background = forms.BooleanField(required=False, initial=False)
-    bck_min = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
-    bck_max = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_min = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={"size": "5"}))
+    bck_max = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck = forms.BooleanField(required=False, initial=False)
-    bck_width = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+    bck_width = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
 
     # Options for second sample
     force_peak_s2 = forms.BooleanField(required=False, initial=False)
-    peak_min_s2 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
-    peak_max_s2 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_min_s2 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
+    peak_max_s2 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
     use_roi_bck_s2 = forms.BooleanField(required=False, initial=False)
     force_background_s2 = forms.BooleanField(required=False, initial=False)
-    bck_min_s2 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
-    bck_max_s2 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_min_s2 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={"size": "5"}))
+    bck_max_s2 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck_s2 = forms.BooleanField(required=False, initial=False)
-    bck_width_s2 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+    bck_width_s2 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
 
     # Options for third sample
     force_peak_s3 = forms.BooleanField(required=False, initial=False)
-    peak_min_s3 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={'size': '5'}))
-    peak_max_s3 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={'size': '5'}))
+    peak_min_s3 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
+    peak_max_s3 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
     use_roi_bck_s3 = forms.BooleanField(required=False, initial=False)
     force_background_s3 = forms.BooleanField(required=False, initial=False)
-    bck_min_s3 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={'size': '5'}))
-    bck_max_s3 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={'size': '5'}))
+    bck_min_s3 = forms.IntegerField(required=True, initial=5, widget=forms.NumberInput(attrs={"size": "5"}))
+    bck_max_s3 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck_s3 = forms.BooleanField(required=False, initial=False)
-    bck_width_s3 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={'size': '4'}))
+    bck_width_s3 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
 
     # List of fields are used in the template
     _template_list = [

--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -306,7 +306,6 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     # Options for all samples in the run
     plot_in_2D = forms.BooleanField(required=False, initial=False)
     use_const_q = forms.BooleanField(required=False, initial=False)
-    const_q_cutoff = forms.FloatField(required=False, initial=0.02)
     q_step = forms.FloatField(required=False, initial=-0.02)
     use_sangle = forms.BooleanField(required=False, initial=True)
     fit_peak_in_roi = forms.BooleanField(required=False, initial=False)
@@ -352,7 +351,6 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
         # Options for all samples in the run
         "plot_in_2D",
         "use_const_q",
-        "const_q_cutoff",
         "q_step",
         "use_sangle",
         "fit_peak_in_roi",

--- a/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
+++ b/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
@@ -92,7 +92,6 @@ Loading the page for each run will take much longer when this option is turned o
         </td>
     </tr>
 
-    <!--  Cutoff (1/&Aring;) {{ options_form.const_q_cutoff }}</td></tr> -->
     <tr class='tiny_input'>
         <td>
             <strong>Q step</strong>

--- a/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
+++ b/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
@@ -65,55 +65,278 @@ Instrument team members can use this page to generate a new automated reduction 
 </div>
 
 <div style="margin-bottom:60px;">
-<p>List of parameters for {{ instrument }} reduction template:</p>
+<p>List of parameters for {{ instrument }} reduction template: (hover over bold-face text for explanation)</p>
 <form action="" method="POST">{% csrf_token %}
+
+
   <table class="property_table  fixed_table" >
-    <tr><th></th> <td></td></tr>
-    <tr><td colspan="2"><br>The ROI in the data file is used to determine the reflectivity peak position.
-    If this ROI is invalid, the system will try to find an appropriate region to use.</td></tr>
 
-    <tr><td colspan="2"><br>You can choose to replace the ROI in the data by your own range.
-    Check the following box if you want to define your own ROI and use it for peak selection.</td></tr>
-    <tr class='tiny_input'><th>Force peak ROI</th><td>{{ options_form.force_peak }}
-                                        <span class='short_label'>Pixel<sub>min</sub></span> {{ options_form.peak_min }}
-                                        <span class='short_label'>Pixel<sub>max</sub></span> {{ options_form.peak_max }}</td></tr>
+    <tr>
+        <td style="font-size: 18px; text-decoration: underline;"><strong>Options for all samples</strong></td>
+    </tr>
 
-    <tr><td colspan="2"><br>A second ROI is available in the data file and can be used to define the background.
-    Check the following box if you want to use the 2nd ROI for your background, otherwise
-    a default region will be used.</td></tr>
-    <tr><th>Use 2nd ROI</th><td onclick="toggle_roi_bck('#{{ options_form.use_roi_bck.id_for_label }}');">{{ options_form.use_roi_bck }}</td></tr>
+    <tr class='tiny_input'>
+        <td>
+            {{ options_form.plot_in_2D }}
+            <span title="Check the following box to see 2D plots on the monitor.
+Loading the page for each run will take much longer when this option is turned on.">
+                <strong>Show 2D plots</strong>
+            </span>
+        </td>
+    </tr>
 
-    <tr><td colspan="2"><br>You can choose to replace the 2nd ROI in the data by your own range.
-    Check the following box if you want to define your own 2nd ROI and use it for background selection.
-    <i>The option to use the 2nd ROI has to be turned ON to use this option.</i></td></tr>
-    <tr class='tiny_input'><th>Force background ROI</th><td><span onclick="toggle_roi_bck('#{{ options_form.force_background.id_for_label }}');">{{ options_form.force_background }}</span>
-                                        <span class='short_label'>Bck<sub>min</sub></span> {{ options_form.bck_min }}
-                                        <span class='short_label'>Bck<sub>max</sub></span> {{ options_form.bck_max }}</td></tr>
+    <tr class='tiny_input'>
+        <td>
+            {{ options_form.use_const_q }}
+            <strong>Use constant-Q binning</strong>
+        </td>
+    </tr>
 
-    <tr><td colspan="2"><br>As an alternative to using the 2nd ROI, you can use a region around the reflected peak to
-    estimate the background. Check the following box if you want to use the region on each side of the peak to estimate your background.</td></tr>
-    <tr class='tiny_input'><th>Use side background</th><td><span onclick="toggle_roi_bck('#{{ options_form.use_side_bck.id_for_label }}');">{{ options_form.use_side_bck }}</span>
-    Pixels on each side {{ options_form.bck_width }}</td></tr>
-
-    <tr><td colspan="2"><br>Once the reflected peak ROI is selected, you can try to fine tune this ROI by fitting for
-    a peak within that region and updating the ROI [both center and width] according to the location found.
-    Check the following box if you want to find a peak within the ROI and redefine the ROI afterwards.</td></tr>
-    <tr><th>Automated ROI</th><td>{{ options_form.fit_peak_in_roi }}</td></tr>
-
-    <tr><td colspan="2"><br>Check the following box if you want to use SANGLE, otherwise DANGLE will be used.</td></tr>
-    <tr><th>Use SANGLE</th><td>{{ options_form.use_sangle }}</td></tr>
-
-    <!-- tr><td colspan="2"><br>When using constant-Q binning, provide a cutoff above which it will be used.</td></tr -->
-    <tr class='tiny_input'><th>Use constant-Q binning</th><td>{{ options_form.use_const_q }} </td></tr>
     <!--  Cutoff (1/&Aring;) {{ options_form.const_q_cutoff }}</td></tr> -->
-    <tr class='tiny_input'><th>Q step</th><td>{{ options_form.q_step }}</td></tr>
+    <tr class='tiny_input'>
+        <td>
+            <strong>Q step</strong>
+            {{ options_form.q_step }}
+        </td>
+    </tr>
 
-    <tr><td colspan="2"><br>Check the following box to see 2D plots on the monitor. Loading the page for
-    each run will take much longer when this option is turned on.</td></tr>
-    <tr class='tiny_input'><th>Show 2D plots</th><td>{{ options_form.plot_in_2D }}</td></tr>
+    <!-- Sample angle options -->
+    <tr>
+        <td>
+            {{ options_form.use_sangle }}
+            <span title="Check the following box if you want to use SANGLE,
+otherwise DANGLE will be used."><strong>Use SANGLE</strong></span>
+        </td>
+    </tr>
+
+    <!-- Automated ROI options -->
+    <tr>
+        <td>
+            {{ options_form.fit_peak_in_roi }}
+            <span title="Once the reflected peak ROI is selected for each sample below,
+you can try to fine tune this ROI by fitting for a peak within that
+region and updating the ROI [both center and width] according to the
+location found. Check the box if you want to find a peak within the
+ROI and redefine the ROI afterwards.">
+                <strong>Automated ROI</strong>
+            </span>
+        </td>
+    </tr>
+
+    <!-- Divider line -->
+    <td colspan="2"><hr></td>
+
+    <!-- Number of Samples in the run -->
+      <tr class='tiny_input'>
+        <td>
+            <span class='short_label' title="Number of samples in the run"><strong>Sample count</strong></span>
+            {{ options_form.sample_count }}
+        </td>
+    </tr>
+
+
+    <!-- Divider line -->
+    <td colspan="2"><hr></td>
+    <tr>
+        <td style="font-size: 18px; text-decoration: underline;"><strong>Sample # 1</strong></td>
+    </tr>
+
+    <!-- Force peak ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_peak }}
+            <span class='short_label' title="You can choose to replace the ROI in the data by your own range.
+Check the following box if you want to define your own ROI and
+use it for peak selection."><strong>Force peak ROI</strong></span>
+            <span class='short_label'>Pixel<sub>min</sub></span>
+            {{ options_form.peak_min }}
+            <span class='short_label'>Pixel<sub>max</sub></span>
+            {{ options_form.peak_max }}
+        </td>
+    </tr>
+
+    <!-- Second ROI options -->
+    <tr>
+        <td onclick="toggle_roi_bck('#{{ options_form.use_roi_bck.id_for_label }}');">
+            {{ options_form.use_roi_bck }}
+            <span title="A second ROI is available in the data file and can be used to define the background.
+Check the following box if you want to use the 2nd ROI for your background,
+otherwise a default region will be used."><strong>Use 2nd ROI</strong></span>
+        </td>
+    </tr>
+
+    <!-- Force background ROI options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.force_background.id_for_label }}');">
+                {{ options_form.force_background }}
+            </span>
+            <span title="You can choose to replace the 2nd ROI in the data by your own range.
+Check the following box if you want to define your own 2nd ROI and use it for background selection.
+The option to use the 2nd ROI has to be turned ON to use this option."><strong>Force background ROI</strong></span>
+            <span class='short_label'>Bck<sub>min</sub></span>
+            {{ options_form.bck_min }}
+            <span class='short_label'>Bck<sub>max</sub></span>
+            {{ options_form.bck_max }}
+        </td>
+    </tr>
+
+    <!-- Side background options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.use_side_bck.id_for_label }}');">
+                {{ options_form.use_side_bck }}
+            </span>
+            <span title="As an alternative to using the 2nd ROI,  you can use a region around
+the reflected peak to estimate the background. Check the following box
+if you want to use the region on each side of the peak to estimate your background.">
+                <strong>Use side background</strong>
+            </span>
+            Pixels on each side {{ options_form.bck_width }}
+        </td>
+    </tr>
+
+
+    <!-- Divider line -->
+    <td colspan="2"><hr></td>
+    <tr>
+        <td style="font-size: 18px; text-decoration: underline;" title="Sample 2 options ignored if Sample count is 1">
+            <strong>Sample # 2</strong>
+        </td>
+    </tr>
+
+    <!-- Force peak ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_peak_s2 }}
+            <span class='short_label' title="You can choose to replace the ROI in the data by your own range.
+Check the following box if you want to define your own ROI and
+use it for peak selection."><strong>Force peak ROI</strong></span>
+            <span class='short_label'>Pixel<sub>min</sub></span>
+            {{ options_form.peak_min_s2 }}
+            <span class='short_label'>Pixel<sub>max</sub></span>
+            {{ options_form.peak_max_s2 }}
+        </td>
+    </tr>
+
+    <!-- Second ROI options -->
+    <tr>
+        <td onclick="toggle_roi_bck('#{{ options_form.use_roi_bck_s2.id_for_label }}');">
+            {{ options_form.use_roi_bck_s2 }}
+            <span title="A second ROI is available in the data file and can be used to define the background.
+Check the following box if you want to use the 2nd ROI for your background,
+otherwise a default region will be used."><strong>Use 2nd ROI</strong></span>
+        </td>
+    </tr>
+
+    <!-- Force background ROI options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.force_background_s2.id_for_label }}');">
+                {{ options_form.force_background_s2 }}
+            </span>
+            <span title="You can choose to replace the 2nd ROI in the data by your own range.
+Check the following box if you want to define your own 2nd ROI and use it for background selection.
+The option to use the 2nd ROI has to be turned ON to use this option."><strong>Force background ROI</strong></span>
+            <span class='short_label'>Bck<sub>min</sub></span>
+            {{ options_form.bck_min_s2 }}
+            <span class='short_label'>Bck<sub>max</sub></span>
+            {{ options_form.bck_max_s2 }}
+        </td>
+    </tr>
+
+    <!-- Side background options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.use_side_bck_s2.id_for_label }}');">
+                {{ options_form.use_side_bck_s2 }}
+            </span>
+            <span title="As an alternative to using the 2nd ROI,  you can use a region around
+the reflected peak to estimate the background. Check the following box
+if you want to use the region on each side of the peak to estimate your background.">
+                <strong>Use side background</strong>
+            </span>
+            Pixels on each side {{ options_form.bck_width_s2 }}
+        </td>
+    </tr>
+
+
+    <!-- Divider line -->
+    <td colspan="2"><hr></td>
+    <tr>
+        <td style="font-size: 18px; text-decoration: underline;" title="Sample 3 options ignored if Sample count smaller than 3">
+            <strong>Sample # 3</strong>
+        </td>
+    </tr>
+
+
+    <!-- Force peak ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_peak_s3 }}
+            <span class='short_label' title="You can choose to replace the ROI in the data by your own range.
+Check the following box if you want to define your own ROI and
+use it for peak selection."><strong>Force peak ROI</strong></span>
+            <span class='short_label'>Pixel<sub>min</sub></span>
+            {{ options_form.peak_min_s3 }}
+            <span class='short_label'>Pixel<sub>max</sub></span>
+            {{ options_form.peak_max_s3 }}
+        </td>
+    </tr>
+
+    <!-- Second ROI options -->
+    <tr>
+        <td onclick="toggle_roi_bck('#{{ options_form.use_roi_bck_s3.id_for_label }}');">
+            {{ options_form.use_roi_bck_s3 }}
+            <span title="A second ROI is available in the data file and can be used to define the background.
+Check the following box if you want to use the 2nd ROI for your background,
+otherwise a default region will be used."><strong>Use 2nd ROI</strong></span>
+        </td>
+    </tr>
+
+    <!-- Force background ROI options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.force_background_s3.id_for_label }}');">
+                {{ options_form.force_background_s3 }}
+            </span>
+            <span title="You can choose to replace the 2nd ROI in the data by your own range.
+Check the following box if you want to define your own 2nd ROI and use it for background selection.
+The option to use the 2nd ROI has to be turned ON to use this option."><strong>Force background ROI</strong></span>
+            <span class='short_label'>Bck<sub>min</sub></span>
+            {{ options_form.bck_min_s3 }}
+            <span class='short_label'>Bck<sub>max</sub></span>
+            {{ options_form.bck_max_s3 }}
+        </td>
+    </tr>
+
+    <!-- Side background options -->
+    <tr class='tiny_input'>
+        <td>
+            <span onclick="toggle_roi_bck('#{{ options_form.use_side_bck_s3.id_for_label }}');">
+                {{ options_form.use_side_bck_s3 }}
+            </span>
+            <span title="As an alternative to using the 2nd ROI,  you can use a region around
+the reflected peak to estimate the background. Check the following box
+if you want to use the region on each side of the peak to estimate your background.">
+                <strong>Use side background</strong>
+            </span>
+            Pixels on each side {{ options_form.bck_width_s3 }}
+        </td>
+    </tr>
+
+
   </table>
+
 <p>
 <span style="float: right; margin-left:15px;" >
+<!--
+- id="submit_button": id of the input element. Used as a hook in JavaScript or CSS to apply styles or behaviors.
+- title="Click to create new reduction script": Tooltip that appears when the user hovers over the input element.
+- type="submit": Means this input field is a submit button for a form. When pressed, it will submit the form data.
+- name="button_choice": name of the input element to be used when collecting the form data.
+- value="submit": Text that appears on the button.
+-->
 <input id="submit_button" title="Click to create new reduction script" type="submit" name="button_choice" value="submit"/>
 <input id="reset_button" title="Click to populate the form with default values" type="submit" name="button_choice" value="reset"/>
 </span>

--- a/src/webmon_app/reporting/tests/test_reduction/test_forms.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_forms.py
@@ -5,99 +5,109 @@ from reporting.reduction.models import ReductionProperty, Choice
 
 
 class TestREFMForm(TestCase):
+    default_test_fields = {
+        "skip_quicknxs": False,
+        # Options for all samples in the run
+        "plot_in_2D": False,
+        "use_const_q": False,
+        "const_q_cutoff": 0.02,
+        "q_step": -0.02,
+        "use_sangle": True,
+        "fit_peak_in_roi": False,
+        "sample_count": 1,
+        # Options for first sample
+        "force_peak": False,
+        "peak_min": 160,
+        "peak_max": 170,
+        "use_roi_bck": False,
+        "force_background": False,
+        "bck_min": 5,
+        "bck_max": 100,
+        "use_side_bck": False,
+        "bck_width": 10,
+        # Options for second sample
+        "force_peak_s2": False,
+        "peak_min_s2": 160,
+        "peak_max_s2": 170,
+        "use_roi_bck_s2": False,
+        "force_background_s2": False,
+        "bck_min_s2": 5,
+        "bck_max_s2": 100,
+        "use_side_bck_s2": False,
+        "bck_width_s2": 10,
+        # Options for third sample
+        "force_peak_s3": False,
+        "peak_min_s3": 160,
+        "peak_max_s3": 170,
+        "use_roi_bck_s3": False,
+        "force_background_s3": False,
+        "bck_min_s3": 5,
+        "bck_max_s3": 100,
+        "use_side_bck_s3": False,
+        "bck_width_s3": 10,
+    }
+
     def test_empty_form(self):
-        default_test_fields = {
-            "use_sangle": True,
-            "use_const_q": False,
-            "use_roi_bck": False,
-            "const_q_cutoff": 0.02,
-            "use_side_bck": False,
-            "bck_width": 10,
-            "fit_peak_in_roi": False,
-            "force_peak": False,
-            "plot_in_2D": False,
-            "peak_min": 160,
-            "peak_max": 170,
-            "force_background": False,
-            "bck_min": 5,
-            "bck_max": 100,
-            "skip_quicknxs": False,
-            "q_step": -0.02,
-        }
-
         form = forms.ReductionConfigurationREFMForm({})
-        self.assertFalse(form.is_valid())
-        for key in default_test_fields:
+        self.assertFalse(form.is_valid())  # empty instantiated form invalid because fields like `peak_min` are required
+        self.assertEqual(len(form.to_template()), len(self.default_test_fields) - 1)  # `skip_quicknxs` missing
+        for key in self.default_test_fields:
             self.assertTrue(key in form.fields)
-
+        # check the values for an empty form. Field values do not correspond to initial values
         self.assertEqual(
             form.to_template(),
             {
-                "bck_max": "",
-                "bck_min": "",
-                "bck_width": "",
-                "const_q_cutoff": "None",
-                "fit_peak_in_roi": "False",
-                "force_background": "False",
-                "force_peak": "False",
-                "peak_max": "",
-                "peak_min": "",
+                # Options for all samples in the run
                 "plot_in_2D": "False",
-                "q_step": "None",
-                "skip_quicknxs": "False",
                 "use_const_q": "False",
-                "use_roi_bck": "False",
+                "const_q_cutoff": "None",
+                "q_step": "None",
                 "use_sangle": "False",
+                "fit_peak_in_roi": "False",
+                "sample_count": "",
+                # Options for first sample
+                "force_peak": "False",
+                "peak_min": "",
+                "peak_max": "",
+                "use_roi_bck": "False",
+                "force_background": "False",
+                "bck_min": "",
+                "bck_max": "",
                 "use_side_bck": "False",
-            },
+                "bck_width": "",
+                # Options for second sample
+                "force_peak_s2": "False",
+                "peak_min_s2": "",
+                "peak_max_s2": "",
+                "use_roi_bck_s2": "False",
+                "force_background_s2": "False",
+                "bck_min_s2": "",
+                "bck_max_s2": "",
+                "use_side_bck_s2": "False",
+                "bck_width_s2": "",
+                # Options for third sample
+                "force_peak_s3": "False",
+                "peak_min_s3": "",
+                "peak_max_s3": "",
+                "use_roi_bck_s3": "False",
+                "force_background_s3": "False",
+                "bck_min_s3": "",
+                "bck_max_s3": "",
+                "use_side_bck_s3": "False",
+                "bck_width_s3": "",
+            }
         )
 
     def test_form_filled(self):
-        test_fields = {
-            "use_sangle": False,
-            "use_const_q": True,
-            "use_roi_bck": True,
-            "const_q_cutoff": 0.04,
-            "use_side_bck": True,
-            "bck_width": 11,
-            "fit_peak_in_roi": True,
-            "force_peak": True,
-            "plot_in_2D": True,
-            "peak_min": 170,
-            "peak_max": 160,
-            "force_background": True,
-            "bck_min": 6,
-            "bck_max": 1000,
-            "skip_quicknxs": True,
-            "q_step": -0.03,
-        }
-
-        form = forms.ReductionConfigurationREFMForm(test_fields)
-        form.full_clean()
-        for key, val in test_fields.items():
+        form = forms.ReductionConfigurationREFMForm(self.default_test_fields)
+        form.full_clean()  # Clean all of form.data and populate form._errors and form.cleaned_data.
+        for key, val in self.default_test_fields.items():
             self.assertEqual(form.cleaned_data.get(key), val)
-
         self.assertTrue(form.is_valid())
+        # form.to_template() returns a dictionary where fields values have been cast as a string
         self.assertEqual(
-            form.to_template(),
-            {
-                "use_sangle": "False",
-                "use_const_q": "True",
-                "const_q_cutoff": "0.04",
-                "fit_peak_in_roi": "True",
-                "plot_in_2D": "True",
-                "force_peak": "True",
-                "peak_min": "170",
-                "peak_max": "160",
-                "q_step": "-0.03",
-                "force_background": "True",
-                "bck_min": "6",
-                "bck_max": "1000",
-                "use_roi_bck": "True",
-                "use_side_bck": "True",
-                "bck_width": "11",
-                "skip_quicknxs": "True",
-            },
+            {**form.to_template(), **{"skip_quicknxs": "False"}},
+            {k: str(v) for k, v in self.default_test_fields.items()},
         )
 
         # this should do nothing, but shouldn't fail
@@ -106,7 +116,7 @@ class TestREFMForm(TestCase):
     def test_to_db(self):
         test_fields = {"const_q_cutoff": 0.04, "bck_width": 11}
         form = forms.ReductionConfigurationREFMForm(test_fields)
-        self.assertFalse(form.is_valid())
+        self.assertFalse(form.is_valid())  # invalid because fields like `peak_min` are required
 
         instrument = Instrument(name="inst")
         instrument.save()

--- a/src/webmon_app/reporting/tests/test_reduction/test_forms.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_forms.py
@@ -10,7 +10,6 @@ class TestREFMForm(TestCase):
         # Options for all samples in the run
         "plot_in_2D": False,
         "use_const_q": False,
-        "const_q_cutoff": 0.02,
         "q_step": -0.02,
         "use_sangle": True,
         "fit_peak_in_roi": False,
@@ -62,7 +61,6 @@ class TestREFMForm(TestCase):
                 # Options for all samples in the run
                 "plot_in_2D": "False",
                 "use_const_q": "False",
-                "const_q_cutoff": "None",
                 "q_step": "None",
                 "use_sangle": "False",
                 "fit_peak_in_roi": "False",
@@ -116,7 +114,7 @@ class TestREFMForm(TestCase):
         form.set_instrument("nonexist")
 
     def test_to_db(self):
-        test_fields = {"const_q_cutoff": 0.04, "bck_width": 11}
+        test_fields = {"bck_width": 11}
         form = forms.ReductionConfigurationREFMForm(test_fields)
         self.assertFalse(form.is_valid())  # invalid because fields like `peak_min` are required
 
@@ -129,10 +127,6 @@ class TestREFMForm(TestCase):
         use_sangle = ReductionProperty.objects.filter(instrument=instrument, key="use_sangle")
         self.assertEqual(len(use_sangle), 1)
         self.assertEqual(use_sangle[0].value, "")
-
-        const_q_cutoff = ReductionProperty.objects.filter(instrument=instrument, key="const_q_cutoff")
-        self.assertEqual(len(const_q_cutoff), 1)
-        self.assertEqual(const_q_cutoff[0].value, "0.04")
 
         bck_width = ReductionProperty.objects.filter(instrument=instrument, key="bck_width")
         self.assertEqual(len(bck_width), 1)

--- a/src/webmon_app/reporting/tests/test_reduction/test_forms.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_forms.py
@@ -49,7 +49,9 @@ class TestREFMForm(TestCase):
 
     def test_empty_form(self):
         form = forms.ReductionConfigurationREFMForm({})
-        self.assertFalse(form.is_valid())  # empty instantiated form invalid because fields like `peak_min` are required
+        self.assertFalse(
+            form.is_valid()
+        )  # empty instantiated form invalid because fields like `peak_min` are required
         self.assertEqual(len(form.to_template()), len(self.default_test_fields) - 1)  # `skip_quicknxs` missing
         for key in self.default_test_fields:
             self.assertTrue(key in form.fields)
@@ -95,7 +97,7 @@ class TestREFMForm(TestCase):
                 "bck_max_s3": "",
                 "use_side_bck_s3": "False",
                 "bck_width_s3": "",
-            }
+            },
         )
 
     def test_form_filled(self):

--- a/src/webmon_app/reporting/tests/test_reduction/test_views.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_views.py
@@ -1,5 +1,3 @@
-import os.path
-
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User

--- a/src/webmon_app/reporting/tests/test_reduction/test_views.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_views.py
@@ -159,7 +159,6 @@ class TestView(TestCase):
                 # Options for all samples in the run
                 "plot_in_2D": True,
                 "use_const_q": False,
-                "const_q_cutoff": 0.02,
                 "q_step": -0.02,
                 "use_sangle": True,
                 "fit_peak_in_roi": False,

--- a/src/webmon_app/reporting/tests/test_reduction/test_views.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_views.py
@@ -1,3 +1,5 @@
+import os.path
+
 from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth.models import User
@@ -156,15 +158,49 @@ class TestView(TestCase):
             reverse("reduction:configuration", args=["ref_m"]),
             data={
                 "button_choice": "submit",
-                "bck_width": 10,
+                # Options for all samples in the run
+                "plot_in_2D": True,
+                "use_const_q": False,
+                "const_q_cutoff": 0.02,
+                "q_step": -0.02,
+                "use_sangle": True,
+                "fit_peak_in_roi": False,
+                "sample_count": 3,
+                # Options for first sample
+                "force_peak": False,
                 "peak_min": 160,
                 "peak_max": 170,
+                "use_roi_bck": False,
+                "force_background": False,
                 "bck_min": 5,
                 "bck_max": 100,
+                "use_side_bck": False,
+                "bck_width": 10,
+                # Options for second sample
+                "force_peak_s2": True,
+                "peak_min_s2": 170,
+                "peak_max_s2": 180,
+                "use_roi_bck_s2": True,
+                "force_background_s2": True,
+                "bck_min_s2": 6,
+                "bck_max_s2": 101,
+                "use_side_bck_s2": True,
+                "bck_width_s2": 11,
+                # Options for third sample
+                "force_peak_s3": False,
+                "peak_min_s3": 180,
+                "peak_max_s3": 190,
+                "use_roi_bck_s3": False,
+                "force_background_s3": False,
+                "bck_min_s3": 7,
+                "bck_max_s3": 102,
+                "use_side_bck_s3": False,
+                "bck_width_s3": 12,
             },
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "reduction/configuration_ref_m.html")
+        # open('/tmp/junk.html', 'wb').write(response.content)  # inspect with the browser
 
     def test_configuration_change(self):
         # no data


### PR DESCRIPTION
References [EWM 5797](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=5797)

# Short description of the changes:
Update the reduction options form for instrument `REF_M` with entries for up to three samples.

# Check list for the pull request
- [x] I have updated tests for my changes

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
Run unit test `test_ref_m`  but first [remove comment to print the HTML form](https://github.com/neutrons/data_workflow/blob/refm_multi_samples/src/webmon_app/reporting/tests/test_reduction/test_views.py#L201). After that point your browser to `file:///tmp/junk.html` to see the form with entries for three samples.
