### PR TITLE
Update postprocessing agent to v3.3

### DIFF
--- a/Dockerfile.autoreducer
+++ b/Dockerfile.autoreducer
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/postprocessing/log/
 COPY tests/configuration/post_process_consumer.conf /etc/autoreduce/post_processing.conf
 
 # install postprocessing
-RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.2/postprocessing-3.2.0-1.el9.noarch.rpm
+RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.3/postprocessing-3.3.0-1.el9.noarch.rpm
 
 # install the fake test data
 ARG DATA_TARBALL=/tmp/SNSdata.tar.gz

--- a/Dockerfile.autoreducer.himem
+++ b/Dockerfile.autoreducer.himem
@@ -15,7 +15,7 @@ RUN mkdir -p /opt/postprocessing/log/
 COPY tests/configuration/post_process_consumer.himem.conf /etc/autoreduce/post_processing.conf
 
 # install postprocessing
-RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.2/postprocessing-3.2.0-1.el9.noarch.rpm
+RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.3/postprocessing-3.3.0-1.el9.noarch.rpm
 
 # install the fake test data
 ARG DATA_TARBALL=/tmp/SNSdata.tar.gz

--- a/tests/test_SubmitPostprocessing.py
+++ b/tests/test_SubmitPostprocessing.py
@@ -89,6 +89,7 @@ class TestPostProcessingAdminView:
         # POSTPROCESS.DATA_READY, should add 6 new RunStatus
         self.send_request("POSTPROCESS.DATA_READY", RUN_NUMBER_GOOD, requestType="submit")
 
+        time.sleep(0.1)
         new_status_count = self.get_status_count(RUN_NUMBER_GOOD)
         assert new_status_count - status_count == 10
 

--- a/tests/test_SubmitPostprocessing.py
+++ b/tests/test_SubmitPostprocessing.py
@@ -89,7 +89,7 @@ class TestPostProcessingAdminView:
         # POSTPROCESS.DATA_READY, should add 6 new RunStatus
         self.send_request("POSTPROCESS.DATA_READY", RUN_NUMBER_GOOD, requestType="submit")
 
-        time.sleep(0.1)
+        time.sleep(0.5)
         new_status_count = self.get_status_count(RUN_NUMBER_GOOD)
         assert new_status_count - status_count == 10
 


### PR DESCRIPTION
# Description of the changes

Update postprocessing agent to v3.3. This is to trigger building the docker image used in the WebMon test environment.

Also had to add a `sleep` to make the system test `testPostProcessingSubmit` pass. In the test, the message `POSTPROCESS.DATA_READY` triggers in sequence: cataloging, then reduction, then reduced data cataloging, and the test checks that the correct number of status messages have been written to the DB.
