### PR TITLE
Show the last workflow RunStatus that a autoreducer node has sent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
         CONFIG_FILE: ./tests/configuration/post_process_consumer.conf
     hostname: autoreducer
     healthcheck:
-      test: ["CMD", "pgrep", "python"]
+      test: ["CMD", "pgrep", "queueProcessor"]
     depends_on:
       activemq:
         condition: service_healthy
@@ -134,7 +134,7 @@ services:
         CONFIG_FILE: ./tests/configuration/post_process_consumer.himem.conf
     hostname: autoreducer.himem
     healthcheck:
-      test: ["CMD", "pgrep", "python"]
+      test: ["CMD", "pgrep", "queueProcessor"]
     depends_on:
       activemq:
         condition: service_healthy

--- a/src/webmon_app/reporting/templates/dasmon/diagnostics.html
+++ b/src/webmon_app/reporting/templates/dasmon/diagnostics.html
@@ -127,7 +127,7 @@ Reported conditions:<br>
 <table>
   <tbody>
 {% for item in post_diagnostics.ar_nodes %}
-    <tr><td>{{ item.node }}: </td><td>{{ item.time }}</td><td>{{ item.msg }}</td></tr>
+    <tr><td style="white-space:nowrap;">{{ item.node }}: </td><td style="white-space:nowrap;">{{ item.time }}</td><td>{{ item.msg }}</td></tr>
 {% endfor %}
   </tbody>
 </table>

--- a/src/webmon_app/reporting/templates/dasmon/diagnostics.html
+++ b/src/webmon_app/reporting/templates/dasmon/diagnostics.html
@@ -127,7 +127,7 @@ Reported conditions:<br>
 <table>
   <tbody>
 {% for item in post_diagnostics.ar_nodes %}
-    <tr><td>{{ item.node }}: </td><td>{{ item.time }}</td></tr>
+    <tr><td>{{ item.node }}: </td><td>{{ item.time }}</td><td>{{ item.msg }}</td></tr>
 {% endfor %}
   </tbody>
 </table>

--- a/tests/test_DASMONPageView.py
+++ b/tests/test_DASMONPageView.py
@@ -35,7 +35,7 @@ class TestDASMONPageView:
         tree = etree.parse(StringIO(dasmon_diagnostics.text), parser)
         table_content = tree.xpath("//tr/td//text()")
         # verify number of entries in the tables
-        expected_number_of_entries = 43
+        expected_number_of_entries = 48
         assert len(table_content) == expected_number_of_entries
         # -- DASMON diagnostics
         status = table_content[1]


### PR DESCRIPTION
# Description of the changes

Ref: [6756: [WebMon] Show autoreducer last non-heartbeat message on diagnostics page](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6756)

This will now show in addition to the heartbeat the last workflow status message sent by the autoreducer nodes.

![2024-09-16-152702_610x141_scrot](https://github.com/user-attachments/assets/3d0df602-731b-4c7b-afa5-f21ea9a4d839)


If when this goes into production it is slow we can add a new table that just has the Parameter for the autoreducer node and the last RunStaus that it sent, which should be a small table compared to the Information table. But at the moment it doesn't seem like an issue.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
