### PR TITLE
Add acquiring status for before data is ready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,9 @@ services:
   activemq:
     image: apache/activemq-classic
     hostname: activemq
+    ports:
+     - 8161:8161
+     - 61613:61613
     volumes:
       - ./src/workflow_app/workflow/icat_activemq.xml:/opt/apache-activemq/conf/activemq.xml
     healthcheck:

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -386,7 +386,9 @@ def get_run_status_text(run_id, show_error=False, use_element_id=False):
         else:
             element_id = ""
         s = WorkflowSummary.objects.get(run_id=run_id)
-        if s.complete is True:
+        if not is_acquisition_complete(run_id):
+            status = "<span %s>acquiring</span>" % element_id
+        elif s.complete is True:
             status = "<span %s class='green'>complete</span>" % element_id
         else:
             last_error = run_id.last_error()

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -356,8 +356,7 @@ def is_acquisition_complete(run_id):
 
     :param run_id: run object
     """
-    status_items = RunStatus.objects.filter(run_id=run_id, queue_id__name="POSTPROCESS.DATA_READY")
-    return len(status_items) > 0
+    return RunStatus.objects.filter(run_id=run_id, queue_id__name="POSTPROCESS.DATA_READY").count() > 0
 
 
 def get_post_processing_status(red_timeout=0.25, yellow_timeout=120):

--- a/src/webmon_app/reporting/templates/dasmon/run_summary.html
+++ b/src/webmon_app/reporting/templates/dasmon/run_summary.html
@@ -83,6 +83,7 @@ function poll(){
   <div style="float: right; margin-left:15px;">
     Status: <select id="search-status" name="status">
       <option></option>
+      <option>acquiring</option>
       <option>complete</option>
       <option>incomplete</option>
       <option>error</option>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 from dotenv import dotenv_values
 import psycopg2
 import pytest
+import stomp
 
 # standard imports
 import requests
@@ -76,3 +77,14 @@ def db_connection():
     time.sleep(1)
     yield conn
     conn.close()
+
+
+@pytest.fixture(scope="session")
+def amq_connection():
+    """activemq connection with config from env files"""
+    config = dotenv_values(".env")
+    assert config
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+    conn.connect(config["ICAT_USER"], config["ICAT_PASS"], wait=True)
+    yield conn
+    conn.disconnect()

--- a/tests/test_SMS_messages.py
+++ b/tests/test_SMS_messages.py
@@ -1,0 +1,88 @@
+"""Test the status acquiring appears when a SMS message is received and before the data is ready"""
+
+import time
+import json
+import tests.utils.db as db_utils
+
+
+class TestSMSQueues:
+    instrument = "arcs"
+    IPTS = "IPTS-11111"
+    user = "InstrumentScientist"
+    pwd = "InstrumentScientist"
+
+    def create_and_send_msg(self, conn, run_number):
+        conn.send(
+            f"/topic/SNS.{self.instrument.upper()}.APP.SMS",
+            json.dumps(
+                {
+                    "instrument": self.instrument,
+                    "facility": "SNS",
+                    "ipts": self.IPTS,
+                    "run_number": run_number,
+                    "data_file": "",
+                    "reason": "SMS run started",
+                    "msg_type": "0",
+                }
+            ),
+        )
+
+    def clear_run(self, conn, run_number):
+        # remove everything for this run
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM report_instrument where name = %s;", (self.instrument,))
+        inst_id = cursor.fetchone()
+        if inst_id is None:
+            return
+
+        cursor.execute(
+            "SELECT id FROM report_datarun WHERE instrument_id_id = %s AND run_number = %s;", (inst_id, run_number)
+        )
+        run_id = cursor.fetchone()
+        if run_id is None:
+            return
+
+        db_utils.clear_previous_runstatus(conn, run_id)
+        cursor.execute("DELETE FROM report_workflowsummary WHERE run_id_id = %s;", run_id)
+        cursor.execute("DELETE FROM report_instrumentstatus WHERE last_run_id_id = %s;", run_id)
+        cursor.execute("DELETE FROM report_datarun WHERE id = %s;", (run_id))
+        conn.commit()
+        cursor.close()
+
+    def test_acquiring(self, amq_connection, db_connection, request_page):
+        # remove data run so the tests always starts fresh
+        self.clear_run(db_connection, 100)
+        self.clear_run(db_connection, 101)
+        # send SMS message for 2 runs
+        self.create_and_send_msg(amq_connection, 100)
+        self.create_and_send_msg(amq_connection, 101)
+
+        # wait a second while things run
+        time.sleep(1)
+
+        # check IPTS page /report/arcs/experiment/IPTS-11111/ for acquiring
+        response = request_page("/report/arcs/experiment/IPTS-11111/", self.user, self.pwd)
+        assert response.status_code == 200
+        assert response.text.count("acquiring") == 2
+
+        # now send data_ready for run 100 only and check that it is no longer acquiring
+        self.create_and_send_msg(amq_connection, 100)
+
+        amq_connection.send(
+            "/queue/POSTPROCESS.DATA_READY",
+            json.dumps(
+                {
+                    "instrument": self.instrument,
+                    "facility": "SNS",
+                    "ipts": self.IPTS,
+                    "run_number": 100,
+                    "data_file": "",
+                }
+            ),
+        )
+        time.sleep(1)
+
+        # check IPTS page /report/arcs/experiment/IPTS-11111/ for acquiring
+        response = request_page("/report/arcs/experiment/IPTS-11111/", self.user, self.pwd)
+        assert response.status_code == 200
+        assert response.text.count("acquiring") == 1  # 101 is still acquiring but not 100


### PR DESCRIPTION
# Description of the changes

[6375: [WebMon] Separate run status "acquiring" from status "incomplete" in WebMon](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6375)

This uses the existing `is_acquisition_complete` method to determine the new status. It works by looking for the `POSTPROCESS.DATA_READY` message for that run to know that the acquisition has finished.


To test yourself you can run the system tests then view the run list pages. Run 100 should show error (file doesn't exist) while 101 should still be "acquiring"

http://localhost/dasmon/summary/

![2024-09-19-153500_640x377_scrot](https://github.com/user-attachments/assets/745ea0b5-ef3d-4074-9bf2-5b88fb7ccb54)


http://localhost/dasmon/arcs/runs/

![2024-09-19-153508_660x253_scrot](https://github.com/user-attachments/assets/749ef1bd-504f-4bd3-bfdb-37e17c27d4d3)


http://localhost/report/arcs/experiment/IPTS-11111/

![2024-09-19-153516_663x193_scrot](https://github.com/user-attachments/assets/4649710a-a462-492b-b539-4fe489fb90f8)


Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
