### PR TITLE
Fix wrong run title shown

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -55,7 +55,11 @@ def get_cached_variables(instrument_id, monitored_only=False):
     :param instrument_id: Instrument object
     :param monitored_only: if True, only monitored parameters are returned
     """
-    parameter_values = StatusCache.objects.filter(instrument_id=instrument_id).order_by("key_id__name")
+    parameter_values = (
+        StatusCache.objects.filter(instrument_id=instrument_id)
+        .order_by("key_id__name", "-timestamp")
+        .distinct("key_id__name")
+    )
     # Variables that are displayed on top
     top_variables = ["run_number", "proposal_id", "run_title"]
     key_value_pairs = []

--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -55,15 +55,19 @@ def get_cached_variables(instrument_id, monitored_only=False):
     :param instrument_id: Instrument object
     :param monitored_only: if True, only monitored parameters are returned
     """
-    parameter_values = (
-        StatusCache.objects.filter(instrument_id=instrument_id)
-        .order_by("key_id__name", "-timestamp")
-        .distinct("key_id__name")
-    )
+    parameter_values = StatusCache.objects.filter(instrument_id=instrument_id).order_by("key_id__name", "-timestamp")
     # Variables that are displayed on top
     top_variables = ["run_number", "proposal_id", "run_title"]
     key_value_pairs = []
+    keys_used = set()
     for kvp in parameter_values:
+
+        if kvp.key_id in keys_used:
+            # only used the first value for each key, will be ordered newest first
+            continue
+
+        keys_used.add(kvp.key_id)
+
         if kvp.key_id.monitored or monitored_only is False:
             # Exclude top variables
             if monitored_only and str(kvp.key_id) in top_variables:

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
@@ -414,7 +414,7 @@ class ViewUtilTest(TestCase):
         assert template["run_number"] == "0"
         assert template["count_rate"] == "-"
         assert template["proposal_id"] == "2"
-        assert template["run_title"] == "testRunTitle"
+        assert template["run_title"] == "testRunTitleNew"
 
     def test_get_live_variables(self):
         from reporting.dasmon.view_util import get_live_variables

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
@@ -41,9 +41,11 @@ class ViewUtilTest(TestCase):
         proposal_id.save()
         run_title = Parameter.objects.create(name="run_title")
         run_title.save()
+
+        # we add the run_title twice to check that the newest one is returned
         for p, v in zip(
-            [para, run_number, cnt_rate, proposal_id, run_title],
-            ["testValue", 0, 1, 2, "testRunTitle"],
+            [para, run_number, cnt_rate, proposal_id, run_title, run_title],
+            ["testValue", 0, 1, 2, "testRunTitle", "testRunTitleNew"],
         ):
             StatusVariable.objects.create(
                 instrument_id=inst,
@@ -106,6 +108,9 @@ class ViewUtilTest(TestCase):
         for d in pairs:
             if d["key"] == "testParam":
                 assert d["value"] == ref_val["value"]
+            if d["key"] == "run_title":
+                # expect run_title==testRunTitleNew because it's newest
+                assert d["value"] == "testRunTitleNew"
         for d in pairs_monitoredOnly:
             if d["key"] == "testParam":
                 assert d["value"] == ref_val["value"]


### PR DESCRIPTION
# Description of the changes

Ref: [6258: [WebMon] Wrong run title shown for HB2C](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6258)

Everywhere that `StatusCache` is accessed it is done with `.latest("timestamp")` except in `get_cached_variables`. This is why initially the page is correct but gets updated with incorrect information. Really this issue should not happen but I guess it must be possible.

I have changed  `get_cached_variables` to sort by name first then newest timestamp, after which we only use the first appearance of that parameter.

You can check that this works by starting webmon with docker and add in additional run_title StatusCache (http://localhost/database/dasmon/statuscache/) and check that the newest is always used.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
