### PR TITLE
Rename 'sample' to 'peak' in auto-reduction code

### DIFF
--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -303,17 +303,17 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
 
     skip_quicknxs = forms.BooleanField(required=False, initial=False)
 
-    # Options for all samples in the run
+    # Options for all peaks in the run
     plot_in_2D = forms.BooleanField(required=False, initial=False)
     use_const_q = forms.BooleanField(required=False, initial=False)
     q_step = forms.FloatField(required=False, initial=-0.02)
     use_sangle = forms.BooleanField(required=False, initial=True)
     fit_peak_in_roi = forms.BooleanField(required=False, initial=False)
-    sample_count = forms.IntegerField(
+    peak_count = forms.IntegerField(
         required=True, min_value=1, initial=1, widget=forms.NumberInput(attrs={"size": "2"})
     )
 
-    # Options for first sample
+    # Options for first peak
     force_peak = forms.BooleanField(required=False, initial=False)
     peak_min = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
     peak_max = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
@@ -324,7 +324,7 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     use_side_bck = forms.BooleanField(required=False, initial=False)
     bck_width = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
 
-    # Options for second sample
+    # Options for second peak
     force_peak_s2 = forms.BooleanField(required=False, initial=False)
     peak_min_s2 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
     peak_max_s2 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
@@ -335,7 +335,7 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
     use_side_bck_s2 = forms.BooleanField(required=False, initial=False)
     bck_width_s2 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
 
-    # Options for third sample
+    # Options for third peak
     force_peak_s3 = forms.BooleanField(required=False, initial=False)
     peak_min_s3 = forms.IntegerField(required=True, initial=160, widget=forms.NumberInput(attrs={"size": "5"}))
     peak_max_s3 = forms.IntegerField(required=True, initial=170, widget=forms.NumberInput(attrs={"size": "5"}))
@@ -348,14 +348,14 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
 
     # List of fields are used in the template
     _template_list = [
-        # Options for all samples in the run
+        # Options for all peaks in the run
         "plot_in_2D",
         "use_const_q",
         "q_step",
         "use_sangle",
         "fit_peak_in_roi",
-        "sample_count",
-        # Options for first sample
+        "peak_count",
+        # Options for first peak
         "force_peak",
         "peak_min",
         "peak_max",
@@ -365,7 +365,7 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
         "bck_max",
         "use_side_bck",
         "bck_width",
-        # Options for second sample
+        # Options for second peak
         "force_peak_s2",
         "peak_min_s2",
         "peak_max_s2",
@@ -375,7 +375,7 @@ class ReductionConfigurationREFMForm(BaseReductionConfigurationForm):
         "bck_max_s2",
         "use_side_bck_s2",
         "bck_width_s2",
-        # Options for third sample
+        # Options for third peak
         "force_peak_s3",
         "peak_min_s3",
         "peak_max_s3",

--- a/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
+++ b/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
@@ -72,7 +72,7 @@ Instrument team members can use this page to generate a new automated reduction 
   <table class="property_table  fixed_table" >
 
     <tr>
-        <td style="font-size: 18px; text-decoration: underline;"><strong>Options for all samples</strong></td>
+        <td style="font-size: 18px; text-decoration: underline;"><strong>Options for all peaks</strong></td>
     </tr>
 
     <tr class='tiny_input'>
@@ -99,7 +99,7 @@ Loading the page for each run will take much longer when this option is turned o
         </td>
     </tr>
 
-    <!-- Sample angle options -->
+    <!-- Peak angle options -->
     <tr>
         <td>
             {{ options_form.use_sangle }}
@@ -112,7 +112,7 @@ otherwise DANGLE will be used."><strong>Use SANGLE</strong></span>
     <tr>
         <td>
             {{ options_form.fit_peak_in_roi }}
-            <span title="Once the reflected peak ROI is selected for each sample below,
+            <span title="Once the reflected peak ROI is selected for each peak below,
 you can try to fine tune this ROI by fitting for a peak within that
 region and updating the ROI [both center and width] according to the
 location found. Check the box if you want to find a peak within the
@@ -125,11 +125,11 @@ ROI and redefine the ROI afterwards.">
     <!-- Divider line -->
     <td colspan="2"><hr></td>
 
-    <!-- Number of Samples in the run -->
+    <!-- Number of Peaks in the run -->
       <tr class='tiny_input'>
         <td>
-            <span class='short_label' title="Number of samples in the run"><strong>Sample count</strong></span>
-            {{ options_form.sample_count }}
+            <span class='short_label' title="Number of peaks in the run"><strong>Peak count</strong></span>
+            {{ options_form.peak_count }}
         </td>
     </tr>
 
@@ -137,7 +137,7 @@ ROI and redefine the ROI afterwards.">
     <!-- Divider line -->
     <td colspan="2"><hr></td>
     <tr>
-        <td style="font-size: 18px; text-decoration: underline;"><strong>Sample # 1</strong></td>
+        <td style="font-size: 18px; text-decoration: underline;"><strong>Peak # 1</strong></td>
     </tr>
 
     <!-- Force peak ROI options -->
@@ -199,8 +199,8 @@ if you want to use the region on each side of the peak to estimate your backgrou
     <!-- Divider line -->
     <td colspan="2"><hr></td>
     <tr>
-        <td style="font-size: 18px; text-decoration: underline;" title="Sample 2 options ignored if Sample count is 1">
-            <strong>Sample # 2</strong>
+        <td style="font-size: 18px; text-decoration: underline;" title="Peak 2 options ignored if Peak count is 1">
+            <strong>Peak # 2</strong>
         </td>
     </tr>
 
@@ -263,8 +263,8 @@ if you want to use the region on each side of the peak to estimate your backgrou
     <!-- Divider line -->
     <td colspan="2"><hr></td>
     <tr>
-        <td style="font-size: 18px; text-decoration: underline;" title="Sample 3 options ignored if Sample count smaller than 3">
-            <strong>Sample # 3</strong>
+        <td style="font-size: 18px; text-decoration: underline;" title="Peak 3 options ignored if Peak count smaller than 3">
+            <strong>Peak # 3</strong>
         </td>
     </tr>
 

--- a/src/webmon_app/reporting/tests/test_reduction/test_views.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_views.py
@@ -162,7 +162,7 @@ class TestView(TestCase):
                 "q_step": -0.02,
                 "use_sangle": True,
                 "fit_peak_in_roi": False,
-                "sample_count": 3,
+                "peak_count": 3,
                 # Options for first sample
                 "force_peak": False,
                 "peak_min": 160,
@@ -173,7 +173,7 @@ class TestView(TestCase):
                 "bck_max": 100,
                 "use_side_bck": False,
                 "bck_width": 10,
-                # Options for second sample
+                # Options for second peak
                 "force_peak_s2": True,
                 "peak_min_s2": 170,
                 "peak_max_s2": 180,
@@ -183,7 +183,7 @@ class TestView(TestCase):
                 "bck_max_s2": 101,
                 "use_side_bck_s2": True,
                 "bck_width_s2": 11,
-                # Options for third sample
+                # Options for third peak
                 "force_peak_s3": False,
                 "peak_min_s3": 180,
                 "peak_max_s3": 190,
@@ -197,7 +197,7 @@ class TestView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "reduction/configuration_ref_m.html")
-        # open('/tmp/junk.html', 'wb').write(response.content)  # inspect with the browser
+        open("/tmp/junk.html", "wb").write(response.content)  # inspect with the browser
 
     def test_configuration_change(self):
         # no data

--- a/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py
+++ b/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py
@@ -46,7 +46,7 @@ def _as_bool(value):
 
 def reduction_user_options():
     r"""Collects all values defined by the user in https://monitor.sns.gov/reduction/ref_m/"""
-    # Options common to all samples:
+    # Options common to all peaks:
     kwargs_common = dict(
         plot_2d=_as_bool(True),
         const_q_binning=_as_bool(False),
@@ -56,8 +56,8 @@ def reduction_user_options():
         publish=False,  # uploading to livedata server to be done later by `upload_html_report()`
     )
 
-    # Options for Sample 1
-    kwargs_sample_1 = dict(
+    # Options for Peak 1
+    kwargs_peak_1 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(True),
         peak_roi=[int(149), int(159)],
@@ -68,8 +68,8 @@ def reduction_user_options():
         bck_offset=int(),
     )
 
-    # Options for Sample 2
-    kwargs_sample_2 = dict(
+    # Options for Peak 2
+    kwargs_peak_2 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(True),
         peak_roi=[int(160), int(180)],
@@ -80,8 +80,8 @@ def reduction_user_options():
         bck_offset=int(),
     )
 
-    # Options for Sample 3
-    kwargs_sample_3 = dict(
+    # Options for Peak 3
+    kwargs_peak_3 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(True),
         peak_roi=[int(160), int(180)],
@@ -92,28 +92,28 @@ def reduction_user_options():
         bck_offset=int(),
     )
 
-    # Do we have more than one sample in this run?
-    sample_count = int(1)
-    ReductionOptions = namedtuple("ReductionOptions", "common, sample_count, sample1, sample2, sample3")
-    return ReductionOptions(kwargs_common, sample_count, kwargs_sample_1, kwargs_sample_2, kwargs_sample_3)
+    # Do we have more than one peak in this run?
+    peak_count = int(1)
+    ReductionOptions = namedtuple("ReductionOptions", "common, peak_count, peak1, peak2, peak3")
+    return ReductionOptions(kwargs_common, peak_count, kwargs_peak_1, kwargs_peak_2, kwargs_peak_3)
 
 
 def reduce_events_file(event_file_path, outdir):
     event_file = os.path.split(event_file_path)[-1]  # file name
-    reports = list()  # autoreduction reports for each sample in the run, in HTML format
+    reports = list()  # autoreduction reports for each peak in the run, in HTML format
     opts = reduction_user_options()
-    assert opts.sample_count <= 3, "Sample count must be <= 3"
-    kwargs_samples = [opts.sample1, opts.sample2, opts.sample3]
-    sample_numbers = (
+    assert opts.peak_count <= 3, "Peak count must be <= 3"
+    kwargs_peaks = [opts.peak1, opts.peak2, opts.peak3]
+    peak_numbers = (
         [
             None,
         ]
-        if opts.sample_count == 1
-        else range(1, opts.sample_count + 1)
+        if opts.peak_count == 1
+        else range(1, opts.peak_count + 1)
     )  # numbers start at 1, not 0
-    for i, sample_number in enumerate(sample_numbers):
-        d = dict(data_run=event_file, output_dir=outdir, sample_number=sample_number)
-        kwargs = {**d, **opts.common, **kwargs_samples[i]}  # merge all partial dicts
+    for i, peak_number in enumerate(peak_numbers):
+        d = dict(data_run=event_file, output_dir=outdir, peak_number=peak_number)
+        kwargs = {**d, **opts.common, **kwargs_peaks[i]}  # merge all partial dicts
         reports.append(ReductionProcess(**kwargs).reduce())
     return reports
 

--- a/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py.template
+++ b/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py.template
@@ -45,7 +45,7 @@ def _as_bool(value):
 
 def reduction_user_options():
     r"""Collects all values defined by the user in https://monitor.sns.gov/reduction/ref_m/"""
-    # Options common to all samples:
+    # Options common to all peaks:
     kwargs_common = dict(
         plot_2d=_as_bool(${plot_in_2D}),
         const_q_binning=_as_bool(${use_const_q}),
@@ -55,8 +55,8 @@ def reduction_user_options():
         publish = False  # uploading to livedata server to be done later by `upload_html_report()`
     )
 
-    # Options for Sample 1
-    kwargs_sample_1 = dict(
+    # Options for Peak 1
+    kwargs_peak_1 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(${force_peak}),
         peak_roi=[int(${peak_min}), int(${peak_max})],
@@ -67,8 +67,8 @@ def reduction_user_options():
         bck_offset=int(${bck_width})
     )
 
-    # Options for Sample 2
-    kwargs_sample_2 = dict(
+    # Options for Peak 2
+    kwargs_peak_2 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(${force_peak_s2}),
         peak_roi=[int(${peak_min_s2}), int(${peak_max_s2})],
@@ -79,8 +79,8 @@ def reduction_user_options():
         bck_offset=int(${bck_width_s2})
     )
 
-    # Options for Sample 3
-    kwargs_sample_3 = dict(
+    # Options for Peak 3
+    kwargs_peak_3 = dict(
         use_roi=True,
         force_peak_roi=_as_bool(${force_peak_s3}),
         peak_roi=[int(${peak_min_s3}), int(${peak_max_s3})],
@@ -91,22 +91,22 @@ def reduction_user_options():
         bck_offset=int(${bck_width_s3}),
     )
 
-    # Do we have more than one sample in this run?
-    sample_count = int(${sample_count})
-    ReductionOptions = namedtuple('ReductionOptions', 'common, sample_count, sample1, sample2, sample3')
-    return ReductionOptions(kwargs_common, sample_count, kwargs_sample_1, kwargs_sample_2, kwargs_sample_3)
+    # Do we have more than one peak in this run?
+    peak_count = int(${peak_count})
+    ReductionOptions = namedtuple('ReductionOptions', 'common, peak_count, peak1, peak2, peak3')
+    return ReductionOptions(kwargs_common, peak_count, kwargs_peak_1, kwargs_peak_2, kwargs_peak_3)
 
 
 def reduce_events_file(event_file_path, outdir):
     event_file = os.path.split(event_file_path)[-1]  # file name
-    reports = list()  # autoreduction reports for each sample in the run, in HTML format
+    reports = list()  # autoreduction reports for each peak in the run, in HTML format
     opts = reduction_user_options()
-    assert opts.sample_count <= 3, "Sample count must be <= 3"
-    kwargs_samples = [opts.sample1, opts.sample2, opts.sample3]
-    sample_numbers = [None, ] if opts.sample_count == 1 else range(1, opts.sample_count + 1)  # numbers start at 1, not 0
-    for i, sample_number in enumerate(sample_numbers):
-        d = dict(data_run=event_file, output_dir=outdir, sample_number=sample_number)
-        kwargs = {**d, **opts.common, **kwargs_samples[i]}  # merge all partial dicts
+    assert opts.peak_count <= 3, "Peak count must be <= 3"
+    kwargs_peaks = [opts.peak1, opts.peak2, opts.peak3]
+    peak_numbers = [None, ] if opts.peak_count == 1 else range(1, opts.peak_count + 1)  # numbers start at 1, not 0
+    for i, peak_number in enumerate(peak_numbers):
+        d = dict(data_run=event_file, output_dir=outdir, peak_number=peak_number)
+        kwargs = {**d, **opts.common, **kwargs_peaks[i]}  # merge all partial dicts
         reports.append(ReductionProcess(**kwargs).reduce())
     return reports
 


### PR DESCRIPTION
Refactored the code to standardize terminology by replacing 'sample' with 'peak'. This change affects variable names, comments, and documentation strings to improve clarity and consistency in the codebase.

# Description of the changes


Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
