### PR TITLE
Remove now unused CATALOG_ID and CATALOG_SECRET

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
       - LDAP_SERVER_URI=${LDAP_SERVER_URI}
       - LDAP_DOMAIN_COMPONENT=${LDAP_DOMAIN_COMPONENT}
       - CATALOG_URL=${CATALOG_URL}
-      - CATALOG_ID=${CATALOG_ID}
-      - CATALOG_SECRET=${CATALOG_SECRET}
       - CATALOG_API_TOKEN=${CATALOG_API_TOKEN}
       - GUNICORN_CMD_ARGS=--reload --workers=8
       - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/docs/developer/instruction/build.rst
+++ b/docs/developer/instruction/build.rst
@@ -109,8 +109,7 @@ been initialized:
    LDAP_USER_DN_TEMPLATE=*****
    LDAP_DOMAIN_COMPONENT=*****
    CATALOG_URL=*****
-   CATALOG_ID=*****
-   CATALOG_SECRET=*****
+   CATALOG_API_TOKEN=*****
 
 It is recommended to store these variables in an ``.envrc`` file and manage their loading/unloading
 into the shell with the `direnv <direnv/>`_ command-line utility.
@@ -121,8 +120,8 @@ The environment variables ``LDAP_SERVER_URI`` and ``LDAP_DOMAIN_COMPONENT`` are 
 Senior developers can provide the values to use,
 then the developer setup can work with Neutron Scattering Division's (NSD) LDAP instance.
 
-The environment variables ``CATALOG_URL``, ``CATALOG_ID`` and
-``CATALOG_SECRET`` can be set to allow run metadata to be retrieved
+The environment variables ``CATALOG_URL`` and ``CATALOG_API_TOKEN``
+can be set to allow run metadata to be retrieved
 from `ONCat <https://oncat.ornl.gov>`_.
 
 Special users

--- a/docs/developer/instruction/deployment.rst
+++ b/docs/developer/instruction/deployment.rst
@@ -17,9 +17,8 @@ Variable               Secret Description
 ====================== ====== ===========
 AMQ_BROKER                    List of ActiveMQ brokers
 APP_SECRET             yes    `Django SECRET_KEY <https://docs.djangoproject.com/en/3.2/ref/settings/#secret-key>`_
-CATALOG_ID             yes    `ONCat client ID <https://oncat.ornl.gov/#/build?section=authentication>`_
-CATALOG_SECRET         yes    `ONCat client secret <https://oncat.ornl.gov/#/build?section=authentication>`_
 CATALOG_URL            yes    `ONCat URL <https://oncat.ornl.gov>`_
+CATALOG_API_TOKEN      yes    `ONCat API token <https://oncat.ornl.gov>`_
 DATABASE_HOST                 PostgreSQL hostname
 DATABASE_NAME                 Database name
 DATABASE_PASS          yes    PostgreSQL Owner password

--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -150,8 +150,6 @@ AUTH_LDAP_USER_ATTR_MAP = {
 
 # ONCat Catalog
 CATALOG_URL = environ.get("CATALOG_URL")
-CATALOG_ID = environ.get("CATALOG_ID")
-CATALOG_SECRET = environ.get("CATALOG_SECRET")
 CATALOG_API_TOKEN = environ.get("CATALOG_API_TOKEN")
 
 # The DB settings are defined the same as in the workflow manager

--- a/src/webmon_app/reporting/reporting_app/settings/unittest.py
+++ b/src/webmon_app/reporting/reporting_app/settings/unittest.py
@@ -17,8 +17,7 @@ DATABASES = {
 DEBUG = True
 
 CATALOG_URL = "catalog.test.xyz"
-CATALOG_ID = "test"
-CATALOG_SECRET = "test"
+CATALOG_API_TOKEN = "test"
 
 del CACHES  # noqa: F821
 


### PR DESCRIPTION
# Description of the changes

WebMon was actually moved to using the API token in #195, this just cleans up the remaining parts.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: 
[8192: [WebMon] Change ONCat authentication method to API token](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8192)

- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
