### PR TITLE
Remove unneeded static files finder

### DIFF
--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -97,11 +97,7 @@ STATICFILES_DIRS = (
 
 # List of finder classes that know how to find static files in
 # various locations.
-STATICFILES_FINDERS = (
-    "django.contrib.staticfiles.finders.FileSystemFinder",
-    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-    #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
-)
+STATICFILES_FINDERS = ("django.contrib.staticfiles.finders.FileSystemFinder",)
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = "-0zoc$fl2fa&amp;rmzeo#uh-qz-k+4^1)_9p1qwby1djzybqtl_nn"


### PR DESCRIPTION

# Description of the changes
FileSystemFinder finds all the files we need, having AppDirectoriesFinder included was just causing some files to be found multiple times.

This should fix all the "Found another file with the destination path" warnings seen when webmon starts.

If you look at the logs `docker logs data_workflow-webmon-1` the warnings should be gone.

You can also verify that all the needed static files are still copied by first removing the volume `docker volume rm data_workflow_web-static`, then start webmon and check everything is still working correctly.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
