### PR TITLE
Fix the urlpatterns for the metrics app to address warnings

### DIFF
--- a/src/webmon_app/reporting/metrics/urls.py
+++ b/src/webmon_app/reporting/metrics/urls.py
@@ -4,10 +4,10 @@ from . import views
 app_name = "metrics"
 
 urlpatterns = [
-    path("/", views.metrics, name="metrics"),
-    path("/workflow_diagnostics/", views.workflow_diagnostics, name="workflow_diagnostics"),
-    path("/postprocessing_diagnostics/", views.postprocessing_diagnostics, name="postprocessing_diagnostics"),
-    path("/instrument_status/", views.instrument_status, name="instrument_status"),
-    path("/run_statuses/", views.run_statuses, name="run_statuses"),
-    path("/run_statuses/<int:minutes>/", views.run_statuses, name="run_statuses"),
+    path("", views.metrics, name="metrics"),
+    path("workflow_diagnostics/", views.workflow_diagnostics, name="workflow_diagnostics"),
+    path("postprocessing_diagnostics/", views.postprocessing_diagnostics, name="postprocessing_diagnostics"),
+    path("instrument_status/", views.instrument_status, name="instrument_status"),
+    path("run_statuses/", views.run_statuses, name="run_statuses"),
+    path("run_statuses/<int:minutes>/", views.run_statuses, name="run_statuses"),
 ]

--- a/src/webmon_app/reporting/reporting_app/urls.py
+++ b/src/webmon_app/reporting/reporting_app/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     path("reduction/", include("reporting.reduction.urls", namespace="reduction")),
     path("pvmon/", include("reporting.pvmon.urls", namespace="pvmon")),
     path("users/", include("reporting.users.urls", namespace="users")),
-    path("metrics", include("reporting.metrics.urls", namespace="metrics")),
+    path("metrics/", include("reporting.metrics.urls", namespace="metrics")),
     path("database/", admin.site.urls),
     path("ht/", include("health_check.urls")),
 ]


### PR DESCRIPTION
# Description of the changes

This will fix the warning during webmon startup `(urls.W002) Your URL pattern '/' [name='metrics'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.`

To test start up webmon and check that the warning is no longer there `docker logs data_workflow-webmon-1`

Also verify that the metrics still work as expected, see #186 

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [8007: [WebMon] Fix warnings when starting up WebMon](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8007)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
