### PR TITLE
Fix warnings coming from models

### DIFF
--- a/src/webmon_app/reporting/dasmon/models.py
+++ b/src/webmon_app/reporting/dasmon/models.py
@@ -97,7 +97,7 @@ class ActiveInstrument(models.Model):
     have their DAS turned ON
     """
 
-    instrument_id = models.ForeignKey(Instrument, unique=True, on_delete=models.CASCADE)
+    instrument_id = models.OneToOneField(Instrument, on_delete=models.CASCADE)
     is_alive = models.BooleanField(default=True)
     is_adara = models.BooleanField(default=True)
     has_pvsd = models.BooleanField(default=False)
@@ -123,7 +123,7 @@ class LegacyURL(models.Model):
     Table of URLs pointing to the legacy instrument status service
     """
 
-    instrument_id = models.ForeignKey(Instrument, unique=True, on_delete=models.CASCADE)
+    instrument_id = models.OneToOneField(Instrument, on_delete=models.CASCADE)
     url = models.CharField(max_length=128)
     long_name = models.CharField(max_length=40)
 

--- a/src/webmon_app/reporting/reduction/models.py
+++ b/src/webmon_app/reporting/reduction/models.py
@@ -37,7 +37,7 @@ class PropertyDefault(models.Model):
     Table of default values
     """
 
-    property = models.ForeignKey(ReductionProperty, unique=True, on_delete=models.CASCADE)
+    property = models.OneToOneField(ReductionProperty, on_delete=models.CASCADE)
     value = models.TextField(blank=True)
     timestamp = models.DateTimeField("timestamp", auto_now=True)
 

--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -366,3 +366,6 @@ TEST_REMOTE_USER = ""
 TEST_REMOTE_PASSWD = ""
 
 GRAVATAR_URL = "https://www.gravatar.com/avatar/"
+
+# set the default auto field type
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/src/workflow_app/workflow/database/report/models.py
+++ b/src/workflow_app/workflow/database/report/models.py
@@ -341,7 +341,7 @@ class WorkflowSummary(models.Model):
     Overall status of the workflow for a given run
     """
 
-    run_id = models.ForeignKey(DataRun, unique=True, on_delete=models.CASCADE)
+    run_id = models.OneToOneField(DataRun, on_delete=models.CASCADE)
 
     # Overall status of the workflow for this run
     complete = models.BooleanField(default=False)
@@ -521,7 +521,7 @@ class InstrumentStatus(models.Model):
     This can be used to quickly access status information.
     """
 
-    instrument_id = models.ForeignKey(Instrument, unique=True, on_delete=models.CASCADE)
+    instrument_id = models.OneToOneField(Instrument, on_delete=models.CASCADE)
     last_run_id = models.ForeignKey(DataRun, null=True, on_delete=models.CASCADE)
 
     class Meta:


### PR DESCRIPTION
# Description of the changes

This fixes the two different types of warning seen coming from the models
```
dasmon.ActiveInstrument.instrument_id: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
	HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
dasmon.ActiveInstrument: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

If you check the logs the warning should no longer be there `docker logs data_workflow-webmon-1`

The change from `ForeignKey(unique=True, ..)` to `OneToOneField` doesn't require a migration as the created table is identical. 

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:  [8007: [WebMon] Fix warnings when starting up WebMon](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8007)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
