### PR TITLE
Add missing build dependency

### DIFF
--- a/conda_development.yml
+++ b/conda_development.yml
@@ -11,6 +11,7 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme=1.2.*
   - lxml
+  - wheel
   - pip
   - pip:
     - check-wheel-contents


### PR DESCRIPTION
# Description of the changes

The post-merge publish step failed to build wheels with the error:

```
ERROR Missing dependencies:
	wheel
```

The failing job: https://github.com/neutrons/data_workflow/actions/runs/12376853545/job/34544952851

It is not clear why this started failing now, but adding `wheel` explicitly in the conda environment file fixes the problem.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
