### PR TITLE
Revert "Merge pull request #169 from neutrons/live_plot_Authorization"

### DIFF
--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -9,9 +9,9 @@ import logging
 import json
 import datetime
 import string
+import httplib2
 import re
 import hashlib
-import requests
 from reporting.report.models import (
     DataRun,
     RunStatus,
@@ -50,6 +50,22 @@ def generate_key(instrument: str, run_id: int):
         return None
 
     return hashlib.sha1(f"{instrument.upper()}{secret_key}{run_id}".encode("utf-8")).hexdigest()
+
+
+def append_key(input_url, instrument, run_id):
+    """
+    Append a live data secret key to a url
+
+    :param input_url: url to modify
+    :param instrument: instrument name
+    :param run_id: run number
+    """
+    client_key = generate_key(instrument, run_id)
+    if client_key is None:
+        return input_url
+    # Determine whether this is the first query string argument of the url
+    delimiter = "&" if "/?" in input_url else "?"
+    return "%s%skey=%s" % (input_url, delimiter, client_key)
 
 
 def fill_template_values(request, **template_args):
@@ -494,12 +510,11 @@ def get_plot_template_dict(run_object=None, instrument=None, run_id=None):
         "plot_label_x": "",
         "plot_label_y": "",
         "update_url": None,
-        "key": generate_key(instrument, run_id),
     }
 
     url_template = string.Template(settings.LIVE_DATA_SERVER)
     live_data_url = url_template.substitute(instrument=instrument, run_number=run_id)
-    live_data_url = "https://{}:{}{}".format(
+    live_data_url = "https://%s:%s%s" % (
         settings.LIVE_DATA_SERVER_DOMAIN,
         settings.LIVE_DATA_SERVER_PORT,
         live_data_url,
@@ -509,7 +524,7 @@ def get_plot_template_dict(run_object=None, instrument=None, run_id=None):
     html_data = get_plot_data_from_server(instrument, run_id, "html")
     if html_data is not None:
         plot_dict["html_data"] = html_data
-        plot_dict["update_url"] = live_data_url + "/html/"
+        plot_dict["update_url"] = append_key("%s/html/" % live_data_url, instrument, run_id)
         if extract_ascii_from_div(html_data) is not None:
             plot_dict["data_url"] = reverse("report:download_reduced_data", args=[instrument, run_id])
         return plot_dict
@@ -519,7 +534,7 @@ def get_plot_template_dict(run_object=None, instrument=None, run_id=None):
 
     # Third, local json data for the d3 plots
     if json_data:
-        plot_dict["update_url"] = live_data_url + "/json/"
+        plot_dict["update_url"] = append_key("%s/json/" % live_data_url, instrument, run_id)
 
     plot_data, x_label, y_label = extract_d3_data_from_json(json_data)
     if plot_data is not None:
@@ -543,17 +558,13 @@ def get_plot_data_from_server(instrument, run_id, data_type="json"):
     try:
         url_template = string.Template(settings.LIVE_DATA_SERVER)
         live_data_url = url_template.substitute(instrument=instrument, run_number=run_id)
-        live_data_url = "https://{}:{}{}/{}/".format(
-            settings.LIVE_DATA_SERVER_DOMAIN,
-            settings.LIVE_DATA_SERVER_PORT,
-            live_data_url,
-            data_type,
-        )
-        key = generate_key(instrument, run_id)
-        headers = {} if key is None else {"Authorization": key}
-        data_request = requests.get(live_data_url, timeout=1.5, headers=headers)
-        if data_request.status_code == 200:
-            json_data = data_request.text
+        live_data_url += "/%s/" % data_type
+        live_data_url = append_key(live_data_url, instrument, run_id)
+        conn = httplib2.HTTPSConnectionWithTimeout(settings.LIVE_DATA_SERVER_DOMAIN, timeout=1.5)
+        conn.request("GET", live_data_url)
+        data_request = conn.getresponse()
+        if data_request.status == 200:
+            json_data = data_request.read()
     except:  # noqa: E722
         logging.exception("Could not pull data from live data server:")
     return json_data

--- a/src/webmon_app/reporting/templates/report/detail.html
+++ b/src/webmon_app/reporting/templates/report/detail.html
@@ -46,9 +46,6 @@
     function get_plot_update() {
         $.ajax({type: "GET",
                 url: "{{update_url}}",
-                headers: {
-                    "Authorization": "{{key}}"
-                },
                 success: function(data) {
                     if (div_data.localeCompare(data) != 0) {
                         div_data = data;

--- a/src/webmon_app/reporting/tests/test_report/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_report/test_view_util.py
@@ -11,7 +11,12 @@ from reporting.report.models import Task
 from reporting.report.models import WorkflowSummary
 from reporting.report.models import StatusQueueMessageCount
 
+import os
 import json
+from reporting import dasmon, report, reporting_app
+import httplib2
+
+_ = [dasmon, report, reporting_app, os, httplib2]
 
 
 class ViewUtilTest(TestCase):
@@ -76,6 +81,21 @@ class ViewUtilTest(TestCase):
         with self.settings(LIVE_PLOT_SECRET_KEY="test_key"):
             rst = generate_key(inst, run_id)
             refval = "d556af22f61bf04e6eb79d88f5c9031230b29b33"
+            self.assertEqual(rst, refval)
+
+    def test_append_key(self):
+        from reporting.report.view_util import append_key
+
+        # case: client_key is None
+        input_url = "www.test.xyz"
+        inst = "test_instrument"
+        run_id = 1
+        rst = append_key(input_url, inst, run_id)
+        self.assertEqual(rst, input_url)
+        # case: client_key is not None
+        with self.settings(LIVE_PLOT_SECRET_KEY="test_key"):
+            rst = append_key(input_url, inst, run_id)
+            refval = f"{input_url}?key=d556af22f61bf04e6eb79d88f5c9031230b29b33"
             self.assertEqual(rst, refval)
 
     @mock.patch(("reporting.dasmon.view_util.fill_template_values"), return_value="passed")
@@ -299,15 +319,17 @@ class ViewUtilTest(TestCase):
         rst = get_plot_template_dict(run, inst, run_id)
         self.assertTrue("html_data" in rst.keys())
 
-    @mock.patch("requests.get")
-    def test_get_plot_data_from_server(self, mockRequestsGet):
+    @mock.patch("httplib2.HTTPSConnectionWithTimeout")
+    def test_get_plot_data_from_server(self, mockHTTPSCon):
         from reporting.report.view_util import get_plot_data_from_server
 
         # mock external dependencies
         getresponse_return = mock.MagicMock()
-        getresponse_return.status_code = 200
-        getresponse_return.text = "test"
-        mockRequestsGet.return_value = getresponse_return
+        getresponse_return.status = 200
+        getresponse_return.read = mock.MagicMock(return_value="test")
+        con_return = mock.MagicMock()
+        con_return.getresponse = mock.MagicMock(return_value=getresponse_return)
+        mockHTTPSCon.return_value = con_return
         # test
         inst = Instrument.objects.get(name="test_instrument")
         run = DataRun.objects.get(run_number=1, instrument_id=inst)

--- a/src/webmon_app/reporting/tests/test_report/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_report/test_view_util.py
@@ -11,12 +11,7 @@ from reporting.report.models import Task
 from reporting.report.models import WorkflowSummary
 from reporting.report.models import StatusQueueMessageCount
 
-import os
 import json
-from reporting import dasmon, report, reporting_app
-import httplib2
-
-_ = [dasmon, report, reporting_app, os, httplib2]
 
 
 class ViewUtilTest(TestCase):
@@ -319,21 +314,19 @@ class ViewUtilTest(TestCase):
         rst = get_plot_template_dict(run, inst, run_id)
         self.assertTrue("html_data" in rst.keys())
 
-    @mock.patch("httplib2.HTTPSConnectionWithTimeout")
-    def test_get_plot_data_from_server(self, mockHTTPSCon):
+    @mock.patch("requests.get")
+    def test_get_plot_data_from_server(self, mockRequestsGet):
         from reporting.report.view_util import get_plot_data_from_server
 
         # mock external dependencies
         getresponse_return = mock.MagicMock()
-        getresponse_return.status = 200
-        getresponse_return.read = mock.MagicMock(return_value="test")
-        con_return = mock.MagicMock()
-        con_return.getresponse = mock.MagicMock(return_value=getresponse_return)
-        mockHTTPSCon.return_value = con_return
+        getresponse_return.status_code = 200
+        getresponse_return.text = "test"
+        mockRequestsGet.return_value = getresponse_return
         # test
         inst = Instrument.objects.get(name="test_instrument")
         run = DataRun.objects.get(run_number=1, instrument_id=inst)
-        rst = get_plot_data_from_server(inst, run)
+        rst = get_plot_data_from_server(inst.name, run)
         self.assertEqual(rst, "test")
 
     def test_extract_d3_data_from_json(self):

--- a/tests/test_livedata.py
+++ b/tests/test_livedata.py
@@ -64,12 +64,10 @@ class TestLiveDataServer:
         key = generate_key(self.instrument, self.run_number)
         ssl_crt_filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../nginx/nginx.crt")
 
-        key = generate_key(self.instrument, self.run_number)
         # first check that the there isn't an existing plot, should 404
         response = requests.get(
-            f"{LIVEDATA_TEST_URL}/plots/{self.instrument}/{self.run_number}/update/html/",
+            f"{LIVEDATA_TEST_URL}/plots/{self.instrument}/{self.run_number}/update/html/?key={key}",
             verify=ssl_crt_filename,
-            headers={"Authorization": key},
         )
         assert response.status_code == 404
 
@@ -78,9 +76,8 @@ class TestLiveDataServer:
 
         # the data should now be on livedata
         response = requests.get(
-            f"{LIVEDATA_TEST_URL}/plots/{self.instrument}/{self.run_number}/update/html/",
+            f"{LIVEDATA_TEST_URL}/plots/{self.instrument}/{self.run_number}/update/html/?key={key}",
             verify=ssl_crt_filename,
-            headers={"Authorization": key},
         )
         assert response.status_code == 200
         assert "Example Plot Data" in response.text
@@ -90,8 +87,7 @@ class TestLiveDataServer:
         # now verify that the run report page is templated correctly
         client = self.get_session()
         page = client.get(f"{WEBMON_TEST_URL}/report/{self.instrument}/{self.run_number}/")
-        assert 'url: "https://172.16.238.222:443/plots/arcs/214583/update/html/"' in page.text
-        assert f'"Authorization": "{key}"' in page.text
+        assert f"https://172.16.238.222:443/plots/arcs/214583/update/html/?key={key}" in page.text
 
 
 def generate_key(instrument, run_id):

--- a/tests/test_livedata.py
+++ b/tests/test_livedata.py
@@ -61,9 +61,9 @@ class TestLiveDataServer:
         return response.text
 
     def test_reduction_request_livedata(self):
-        key = generate_key(self.instrument, self.run_number)
         ssl_crt_filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../nginx/nginx.crt")
 
+        key = generate_key(self.instrument, self.run_number)
         # first check that the there isn't an existing plot, should 404
         response = requests.get(
             f"{LIVEDATA_TEST_URL}/plots/{self.instrument}/{self.run_number}/update/html/?key={key}",


### PR DESCRIPTION
This reverts commit 157d1ba2e00497d5fb57d829910ac881305b8dda, reversing changes made to 636c61e20f1007ced922a22d84a016da758e98d6.

# Description of the changes

This draft PR is a contingency plan to be able to upgrade the WebMon version without upgrading Live Data Server. It rolls back the change to pass the Live Data Server API key in the authorization header rather than the URL.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
