### PR TITLE
Upgrade to Django 4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: ## Check python dependencies
 	echo CONDA_PREFIX=${CONDA_PREFIX}
 
 	@python -c "import django" || echo "\nERROR: Django is not installed: www.djangoproject.com\n"
-	@python -c "import psycopg2" || echo "\nWARNING: psycopg2 is not installed: http://initd.org/psycopg\n"
+	@python -c "import psycopg" || echo "\nWARNING: psycopg is not installed: http://initd.org/psycopg\n"
 	@python -c "import stomp" || echo "\nERROR: stomp.py is not installed: http://code.google.com/p/stomppy\n"
 
 wheel/dasmon: ## create or update python wheel for service "dasmon". Clean up build/ first

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 prefix := /var/www/workflow
-PYTHON_VERSION:=3.10
+PYTHON_VERSION:=3.12
 
 # these are defined here because I couldn't figure out how to evaluate the commands
 # during target execution rather then when make parses the file

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Dependencies:
  * `stomp <https://github.com/jasonrbriggs/stomp.py>`_
  * `django <https://www.djangoproject.com/>`_
  * `MySQLdb <https://sourceforge.net/projects/mysql-python/>`_ if using MySQL
- * `psycopg2 <https://www.psycopg.org/>`_ if using PostgreSQL
+ * `psycopg <https://www.psycopg.org/>`_ if using PostgreSQL
 
 It consists of 3 applications (Workflow Manager, Web Monitor, and DASMON Listener) which are deployed via docker compose.
 

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -4,8 +4,8 @@ dependencies:
   - flake8
   - python-dotenv
   - python-build
-  - pytest<7
-  - pytest-django<4.6
+  - pytest
+  - pytest-django
   - pytest-cov
   - pre-commit
   - sphinx
@@ -13,4 +13,3 @@ dependencies:
   - lxml
   - wheel
   - check-wheel-contents
-  - pytest-pythonpath

--- a/conda_development.yml
+++ b/conda_development.yml
@@ -12,7 +12,5 @@ dependencies:
   - sphinx_rtd_theme=1.2.*
   - lxml
   - wheel
-  - pip
-  - pip:
-    - check-wheel-contents
-    - pytest-pythonpath
+  - check-wheel-contents
+  - pytest-pythonpath

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -24,4 +24,4 @@ dependencies:
   - django-health-check
   - pip
   - pip:
-    - django-auth-ldap==4.1.0
+    - django-auth-ldap==5.1.0

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - httplib2
   - make
   - oauthlib
-  - postgresql=14
-  - psycopg2-binary=2.9.3
+  - postgresql
+  - psycopg>=3.1.8
   - psutil
   - python-ldap>=3.1
   - requests-oauthlib
@@ -21,7 +21,7 @@ dependencies:
   - pyoncat
   - sphinx_rtd_theme=1.2.*  # readthedocs use this env file, and we need to install this theme here
   - sphinxcontrib-mermaid
+  - django-health-check
   - pip
   - pip:
     - django-auth-ldap==4.1.0
-    - django-health-check

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -4,7 +4,7 @@ channels:
   - oncat
 dependencies:
   - python=3.10
-  - django=3.2
+  - django=4.2
   - gunicorn
   - httplib2
   - make

--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - oncat
 dependencies:
-  - python=3.10
+  - python=3.12
   - django=4.2
   - gunicorn
   - httplib2

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ ignore = E722, W504, W503
 max-line-length = 120
 
 [tool:pytest]
-python_paths = src/ src/dasmon_app src/webmon_app src/workflow_app
+pythonpath = src/ src/dasmon_app src/webmon_app src/workflow_app
 
 [coverage:run]
 source = src

--- a/src/dasmon_app/dasmon_listener/settings.py
+++ b/src/dasmon_app/dasmon_listener/settings.py
@@ -5,7 +5,7 @@ import json
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",  # , 'mysql', 'sqlite3' or 'oracle'.
+        "ENGINE": "django.db.backends.postgresql",  # , 'mysql', 'sqlite3' or 'oracle'.
         "NAME": os.environ.get("DATABASE_NAME"),  # Or path to database file if using sqlite3.
         "USER": os.environ.get("DATABASE_USER"),  # Not used with sqlite3.
         "PASSWORD": os.environ.get("DATABASE_PASS"),  # Not used with sqlite3.

--- a/src/webmon_app/docker-entrypoint.sh
+++ b/src/webmon_app/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-MANAGE_PY_WEBMON="/opt/conda/lib/python3.10/site-packages/reporting/manage.py"
+MANAGE_PY_WEBMON="/opt/conda/lib/python3.12/site-packages/reporting/manage.py"
 
 # wait for postgress to be available
 until PGPASSWORD=${DATABASE_PASS} psql -h "${DATABASE_HOST}" -U "${DATABASE_USER}" -d "${DATABASE_NAME}" -c '\q'; do

--- a/src/webmon_app/reporting/dasmon/urls.py
+++ b/src/webmon_app/reporting/dasmon/urls.py
@@ -2,7 +2,7 @@
 """
     Define url structure
 """
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 app_name = "dasmon"

--- a/src/webmon_app/reporting/pvmon/urls.py
+++ b/src/webmon_app/reporting/pvmon/urls.py
@@ -2,7 +2,7 @@
 """
     Define url structure
 """
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 app_name = "pvmon"

--- a/src/webmon_app/reporting/reduction/urls.py
+++ b/src/webmon_app/reporting/reduction/urls.py
@@ -2,7 +2,7 @@
 """
     Define url structure
 """
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 app_name = "reduction"

--- a/src/webmon_app/reporting/report/urls.py
+++ b/src/webmon_app/reporting/report/urls.py
@@ -2,7 +2,7 @@
 """
     Define url structure
 """
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 app_name = "report"

--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -61,10 +61,6 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale.
-USE_L10N = True
-
 # If you set this to False, Django will not use timezone-aware datetimes.
 USE_TZ = True
 
@@ -151,7 +147,7 @@ CATALOG_API_TOKEN = environ.get("CATALOG_API_TOKEN")
 # The DB settings are defined the same as in the workflow manager
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",  # , 'mysql', 'sqlite3' or 'oracle'.
+        "ENGINE": "django.db.backends.postgresql",  # , 'mysql', 'sqlite3' or 'oracle'.
         "NAME": environ.get("DATABASE_NAME"),  # Or path to database file if using sqlite3.
         "USER": environ.get("DATABASE_USER"),  # Not used with sqlite3.
         "PASSWORD": environ.get("DATABASE_PASS"),  # Not used with sqlite3.

--- a/src/webmon_app/reporting/reporting_app/urls.py
+++ b/src/webmon_app/reporting/reporting_app/urls.py
@@ -2,7 +2,6 @@
 """
     Define url structure
 """
-# from django.conf.urls import include, re_path
 from django.urls import include, path
 from django.contrib.auth.decorators import login_required
 

--- a/src/webmon_app/reporting/users/urls.py
+++ b/src/webmon_app/reporting/users/urls.py
@@ -2,7 +2,7 @@
 """
     Define url structure
 """
-from django.conf.urls import re_path
+from django.urls import re_path
 from . import views
 
 app_name = "users"

--- a/src/workflow_app/workflow/database/settings.py
+++ b/src/workflow_app/workflow/database/settings.py
@@ -3,7 +3,7 @@ import json
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",  # , 'mysql', 'sqlite3' or 'oracle'.
+        "ENGINE": "django.db.backends.postgresql",  # , 'mysql', 'sqlite3' or 'oracle'.
         "NAME": os.environ.get("DATABASE_NAME"),  # Or path to database file if using sqlite3.
         "USER": os.environ.get("DATABASE_USER"),  # Not used with sqlite3.
         "PASSWORD": os.environ.get("DATABASE_PASS"),  # Not used with sqlite3.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # third-party imports
 from dotenv import dotenv_values
-import psycopg2
+import psycopg
 import pytest
 import stomp
 
@@ -67,8 +67,8 @@ def db_connection():
     """Database connection with config from env files"""
     config = {**dotenv_values(".env"), **dotenv_values(".env.ci")}
     assert config
-    conn = psycopg2.connect(
-        database=config["DATABASE_NAME"],
+    conn = psycopg.connect(
+        dbname=config["DATABASE_NAME"],
         user=config["DATABASE_USER"],
         password=config["DATABASE_PASS"],
         port=config["DATABASE_PORT"],

--- a/tests/test_PostProcessWorkflow.py
+++ b/tests/test_PostProcessWorkflow.py
@@ -1,4 +1,4 @@
-import psycopg2
+import psycopg
 import requests
 import time
 from django.conf import settings
@@ -13,8 +13,8 @@ class TestPostProcessingWorkflow:
     def setup_class(cls):
         config = {**dotenv_values(".env"), **dotenv_values(".env.ci")}
         assert config
-        cls.conn = psycopg2.connect(
-            database=config["DATABASE_NAME"],
+        cls.conn = psycopg.connect(
+            dbname=config["DATABASE_NAME"],
             user=config["DATABASE_USER"],
             password=config["DATABASE_PASS"],
             port=config["DATABASE_PORT"],

--- a/tests/test_SMS_messages.py
+++ b/tests/test_SMS_messages.py
@@ -36,16 +36,18 @@ class TestSMSQueues:
             return
 
         cursor.execute(
-            "SELECT id FROM report_datarun WHERE instrument_id_id = %s AND run_number = %s;", (inst_id, run_number)
+            "SELECT id FROM report_datarun WHERE instrument_id_id = %s AND run_number = %s;", (inst_id[0], run_number)
         )
         run_id = cursor.fetchone()
         if run_id is None:
             return
 
+        run_id = run_id[0]
+
         db_utils.clear_previous_runstatus(conn, run_id)
-        cursor.execute("DELETE FROM report_workflowsummary WHERE run_id_id = %s;", run_id)
-        cursor.execute("DELETE FROM report_instrumentstatus WHERE last_run_id_id = %s;", run_id)
-        cursor.execute("DELETE FROM report_datarun WHERE id = %s;", (run_id))
+        cursor.execute("DELETE FROM report_workflowsummary WHERE run_id_id = %s;", (run_id,))
+        cursor.execute("DELETE FROM report_instrumentstatus WHERE last_run_id_id = %s;", (run_id,))
+        cursor.execute("DELETE FROM report_datarun WHERE id = %s;", (run_id,))
         conn.commit()
         cursor.close()
 

--- a/tests/test_SubmitPostprocessing.py
+++ b/tests/test_SubmitPostprocessing.py
@@ -1,6 +1,6 @@
 import requests
 import time
-import psycopg2
+import psycopg
 import pytest
 
 INSTRUMENT = "arcs"
@@ -12,8 +12,8 @@ IPTS = "IPTS-27800"
 class TestPostProcessingAdminView:
     def setup_class(cls):
         # connect to DB
-        cls.conn = psycopg2.connect(
-            database="workflow",
+        cls.conn = psycopg.connect(
+            dbname="workflow",
             user="workflow",
             password="workflow",
             port="5432",

--- a/tests/test_livedata.py
+++ b/tests/test_livedata.py
@@ -2,7 +2,7 @@ import time
 import os
 import hashlib
 
-import psycopg2
+import psycopg
 import requests
 
 LIVEDATA_TEST_URL = "https://172.16.238.222"
@@ -17,8 +17,8 @@ class TestLiveDataServer:
     @classmethod
     def setup_class(cls):
         """Clean the database before running tests"""
-        conn = psycopg2.connect(
-            database=os.environ.get("DATABASE_NAME", "workflow"),
+        conn = psycopg.connect(
+            dbname=os.environ.get("DATABASE_NAME", "workflow"),
             user=os.environ.get("DATABASE_USER", "workflow"),
             password=os.environ.get("DATABASE_PASS", "workflow"),
             port=os.environ.get("DATABASE_PORT", 5432),

--- a/tests/test_setInstrumentPVs.py
+++ b/tests/test_setInstrumentPVs.py
@@ -1,5 +1,5 @@
-import psycopg2.errors as pge
-import psycopg2
+import psycopg.errors as pge
+import psycopg
 import argparse
 import os
 import unittest
@@ -14,8 +14,8 @@ class TestSetInstrumentPVs(unittest.TestCase):
 
     @classmethod
     def get_db_conn(cls, options):
-        conn = psycopg2.connect(
-            database=options.database,
+        conn = psycopg.connect(
+            dbname=options.database,
             user=options.user,
             password=options.password,
             host=options.host,
@@ -42,17 +42,18 @@ class TestSetInstrumentPVs(unittest.TestCase):
         cursor = cls.conn.cursor()
         cursor.execute("INSERT INTO report_instrument (name) VALUES (%s);", (instrument,))
         cursor.execute("SELECT id FROM report_instrument where name = %s;", (instrument,))
-        inst_id = cursor.fetchone()
+        inst_id = cursor.fetchone()[0]
         for pv in pvs:
-            cursor.execute("INSERT INTO pvmon_pvname (name, monitored) VALUES (%s, 't');", (pv,))
+            cursor.execute("INSERT INTO pvmon_pvname (name, monitored) VALUES (%s, %s);", (pv, "t"))
         cursor.execute("SELECT id FROM pvmon_pvname where name = ANY(%s);", (pvs,))
         pv_ids = cursor.fetchall()
         for each in pv_ids:
             cursor.execute(
                 "INSERT INTO pvmon_pv (instrument_id, name_id, value, status, update_time) VALUES (%s, %s, 0.0, 0, 0);",
-                [inst_id, each],
+                (inst_id, each[0]),
             )
-            clean_pv_ids.append((inst_id[0], each[0]))
+            clean_pv_ids.append((inst_id, each[0]))
+
         return clean_pv_ids
 
     @classmethod
@@ -65,7 +66,11 @@ class TestSetInstrumentPVs(unittest.TestCase):
         expected_values = [self.ids[0], self.ids[1]]
 
         cursor = self.conn.cursor()
-        cursor.execute("SELECT setInstrumentPVs(%s::character varying, ARRAY[%s])", (test_instrument, test_pvs))
+        cursor.execute(
+            "SELECT setInstrumentPVs('{}'::character varying, ARRAY[{}])".format(
+                test_instrument, ",".join(f"'{pv}'" for pv in test_pvs)
+            )
+        )
         cursor.execute("SELECT instrument_id, pv_name_id FROM pvmon_monitoredvariable;")
         result = cursor.fetchall()
         self.assertListEqual(expected_values, result)
@@ -76,19 +81,22 @@ class TestSetInstrumentPVs(unittest.TestCase):
         expected_values = self.ids
 
         cursor = self.conn.cursor()
-        cursor.execute("SELECT setInstrumentPVs(%s::character varying, ARRAY[%s])", (test_instrument, test_pvs))
+        cursor.execute(
+            "SELECT setInstrumentPVs('{}'::character varying, ARRAY[{}])".format(
+                test_instrument, ",".join(f"'{pv}'" for pv in test_pvs)
+            )
+        )
         cursor.execute("SELECT instrument_id, pv_name_id FROM pvmon_monitoredvariable;")
         result = cursor.fetchall()
         self.assertListEqual(expected_values, result)
 
     def test_monitor_none(self):
         test_instrument = "inst1"
-        test_pvs = []
         expected_values = [(self.ids[0][0], None)]
 
         cursor = self.conn.cursor()
 
-        cursor.execute("SELECT setInstrumentPVs(%s::character varying, ARRAY[%s])", (test_instrument, test_pvs))
+        cursor.execute("SELECT setInstrumentPVs('{}'::character varying, ARRAY[]::text[])".format(test_instrument))
         cursor.execute("SELECT instrument_id, pv_name_id FROM pvmon_monitoredvariable;")
         result = cursor.fetchall()
         self.assertListEqual(expected_values, result)
@@ -100,7 +108,11 @@ class TestSetInstrumentPVs(unittest.TestCase):
 
         cursor = self.conn.cursor()
 
-        cursor.execute("SELECT setInstrumentPVs(%s::character varying, ARRAY[%s])", (test_instrument, test_pvs))
+        cursor.execute(
+            "SELECT setInstrumentPVs('{}'::character varying, ARRAY[{}])".format(
+                test_instrument, ",".join(f"'{pv}'" for pv in test_pvs)
+            )
+        )
         cursor.execute("SELECT instrument_id, pv_name_id FROM pvmon_monitoredvariable;")
         result = cursor.fetchall()
         self.assertListEqual(expected_values, result)
@@ -111,4 +123,8 @@ class TestSetInstrumentPVs(unittest.TestCase):
 
         cursor = self.conn.cursor()
         with self.assertRaises(pge.RaiseException):
-            cursor.execute("SELECT setInstrumentPVs(%s::character varying, ARRAY[%s])", (test_instrument, test_pvs))
+            cursor.execute(
+                "SELECT setInstrumentPVs('{}'::character varying, ARRAY[{}])".format(
+                    test_instrument, ",".join(f"'{pv}'" for pv in test_pvs)
+                )
+            )

--- a/tests/utils/db.py
+++ b/tests/utils/db.py
@@ -7,7 +7,7 @@ def get_status_queue_id(db_connection, queue_name):
     """
     Return the id for the statusqueue for the provided name
 
-    :param psycopg2.Connection db_connection: database connection
+    :param psycopg.Connection db_connection: database connection
     :param int run_id: ID of the run in table datarun
     :param str queue_name: status queue
     :return: int, ID of the status queue in table statusqueue
@@ -31,14 +31,14 @@ def check_run_status_exist(db_connection, run_id, queue_name):
     """
     Return if the run status was created for the given run_id and queue_name
 
-    :param psycopg2.Connection db_connection: database connection
+    :param psycopg.Connection db_connection: database connection
     :param int run_id: ID of the run in table datarun
     :param str queue_name: status queue
     :return: bool
     """
     cursor = db_connection.cursor()
     queue_id = get_status_queue_id(db_connection, queue_name)
-    cursor.execute("SELECT * FROM report_runstatus WHERE run_id_id = %s AND queue_id_id = %s", (run_id[0], queue_id))
+    cursor.execute("SELECT * FROM report_runstatus WHERE run_id_id = %s AND queue_id_id = %s", (run_id, queue_id))
     result = cursor.fetchone() is not None
     cursor.close()
     return result
@@ -48,7 +48,7 @@ def clear_previous_runstatus(db_connection, run_id):
     """
     Remove all previous run statuses for the given run_id
 
-    :param psycopg2.Connection db_connection: database connection
+    :param psycopg.Connection db_connection: database connection
     :param tuple(int,) run_id: ID of the run in table datarun
     """
     cursor = db_connection.cursor()
@@ -56,14 +56,14 @@ def clear_previous_runstatus(db_connection, run_id):
     cursor.execute(
         "DELETE FROM report_error WHERE run_status_id_id IN (SELECT id FROM report_runstatus "
         "WHERE run_id_id = %s);",
-        run_id,
+        (run_id,),
     )
     cursor.execute(
         "DELETE FROM report_information WHERE run_status_id_id IN (SELECT id FROM report_runstatus "
         "WHERE run_id_id = %s);",
-        run_id,
+        (run_id,),
     )
-    cursor.execute("DELETE FROM report_runstatus WHERE run_id_id = %s;", run_id)
+    cursor.execute("DELETE FROM report_runstatus WHERE run_id_id = %s;", (run_id,))
     db_connection.commit()
     cursor.close()
 
@@ -74,7 +74,7 @@ def add_instrument_data_run(conn, instrument, ipts, run_number, facility="SNS"):
 
     Returns the id for the created rundata
 
-    :param psycopg2.Connection conn: database connection
+    :param psycopg.Connection conn: database connection
     :param str instrument: instrument
     :param str ipts: IPTS identifier, e.g. "IPTS-1234"
     :param int run_number: run number
@@ -128,14 +128,14 @@ def add_instrument_data_run(conn, instrument, ipts, run_number, facility="SNS"):
         conn.commit()
     cursor.close()
 
-    return run_id
+    return run_id[0]
 
 
 def check_error_msg_contains(conn, run_id, error_msg):
     """
     Return if there is an error record for the run that contains error_msg in description
 
-    :param psycopg2.Connection conn: database connection
+    :param psycopg.Connection conn: database connection
     :param int run_id: ID of the run in table datarun
     :param str error_msg: error msg to check for
     :return: bool


### PR DESCRIPTION
# Description of the changes

* Moved from Django 3.2 to 4.2
* Django 4.2 allows us to use psycopg 3 instead of 2, so I have updated that as well.
* Also moved to newer python 3.12 (newest supported by django 4.2) which then allowed a newer version of pytest.
* Updated to newest django-auth-ldap. I manually tested that ldap still works.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [8752: [WebMon] Upgrade to Django 4.2](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8752)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
