### PR TITLE
Configure CSRF as required by Django 4.2

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - setuptools
   - stomp.py=8
   - urllib3
-  - versioningit~=1.1
+  - versioningit
   - pyoncat
   - sphinx_rtd_theme=1.2.*  # readthedocs use this env file, and we need to install this theme here
   - sphinxcontrib-mermaid

--- a/src/dasmon_app/pyproject.toml
+++ b/src/dasmon_app/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "wheel", "toml", "versioningit ~= 1.1"]
+requires = ["setuptools >= 42", "wheel", "toml", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]

--- a/src/webmon_app/pyproject.toml
+++ b/src/webmon_app/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "wheel", "toml", "versioningit ~= 1.1"]
+requires = ["setuptools >= 42", "wheel", "toml", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.check-wheel-contents]

--- a/src/webmon_app/reporting/reporting_app/settings/base.py
+++ b/src/webmon_app/reporting/reporting_app/settings/base.py
@@ -34,7 +34,6 @@ BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 
 
 DEBUG = environ.get("DEBUG", True)
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -98,15 +97,6 @@ STATICFILES_FINDERS = ("django.contrib.staticfiles.finders.FileSystemFinder",)
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = "-0zoc$fl2fa&amp;rmzeo#uh-qz-k+4^1)_9p1qwby1djzybqtl_nn"
 
-# ------- Template settings for Django 1.6 ------
-TEMPLATE_LOADERS = (
-    "django.template.loaders.filesystem.Loader",
-    "django.template.loaders.app_directories.Loader",
-    #     'django.template.loaders.eggs.Loader',
-)
-TEMPLATE_DIRS = (BASE_DIR / "templates",)
-# ------ End of template settings for Django 1.6 ------
-
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -160,7 +150,7 @@ DATABASES = {
     }
 }
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -170,7 +160,6 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
-MIDDLEWARE = MIDDLEWARE_CLASSES
 
 ROOT_URLCONF = "reporting.reporting_app.urls"
 

--- a/src/webmon_app/reporting/reporting_app/settings/prod.py
+++ b/src/webmon_app/reporting/reporting_app/settings/prod.py
@@ -13,3 +13,6 @@ if not SECRET_KEY or SECRET_KEY == "UNSET_SECRET":
 DEBUG = environ.get("DEBUG", False)
 
 validate_ldap_settings(server_uri=AUTH_LDAP_SERVER_URI, user_dn_template=AUTH_LDAP_USER_DN_TEMPLATE)  # noqa: F405
+
+CSRF_TRUSTED_ORIGINS = ["https://monitor.sns.gov", "https://webmon-test.ornl.gov"]
+CSRF_COOKIE_SECURE = True

--- a/src/workflow_app/pyproject.toml
+++ b/src/workflow_app/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "wheel", "toml", "versioningit ~= 1.1"]
+requires = ["setuptools >= 42", "wheel", "toml", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]


### PR DESCRIPTION
# Description of the changes

Add the setting `CSRF_TRUSTED_ORIGINS` to the prod settings as required by Django >= 4.0 when using SSL. The prod settings are used also in the test environment, therefore, both the test and prod domains are added.

https://docs.djangoproject.com/en/5.1/releases/4.0/#csrf-trusted-origins-changes

Also cleans up some deprecated settings and removes an old pin of `versioninigt`.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 9434: [WebMon] CSRF verification failed when logging in](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9434)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
