### PR TITLE
Add system test for Post-Processing Agent job time limit

### DIFF
--- a/Dockerfile.autoreducer
+++ b/Dockerfile.autoreducer
@@ -19,7 +19,7 @@ ARG CONFIG_FILE=tests/configuration/post_process_consumer.conf
 COPY ${CONFIG_FILE} /etc/autoreduce/post_processing.conf
 
 # install postprocessing
-RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.3.4/postprocessing-3.3.4-1.el9.noarch.rpm
+RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v3.4.0/postprocessing-3.4.0-1.el9.noarch.rpm
 
 # install the fake test data
 ARG DATA_TARBALL=/tmp/SNSdata.tar.gz

--- a/tests/configuration/post_process_consumer.conf
+++ b/tests/configuration/post_process_consumer.conf
@@ -28,6 +28,7 @@
     "publish_url_template": "https://172.16.238.222/plots/$instrument/$run_number/upload_plot_data/",
     "publisher_username": "workflow",
     "publisher_password": "workflow",
-    "system_mem_limit_perc": 10,
-    "mem_check_interval_sec": 0.1
+    "system_mem_limit_perc": 5,
+    "mem_check_interval_sec": 0.01,
+    "task_time_limit_minutes": 0.1
 }

--- a/tests/data/NOM/shared/autoreduce/reduce_NOM.py
+++ b/tests/data/NOM/shared/autoreduce/reduce_NOM.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import sys
+import time
+from datetime import datetime
+
+print("Running reduction for " + sys.argv[1] + " at " + datetime.isoformat(datetime.now()))
+
+time.sleep(10)

--- a/tests/test_autoreducer_time_limit.py
+++ b/tests/test_autoreducer_time_limit.py
@@ -1,0 +1,37 @@
+"""
+Test of the autoreducer memory management that sets a max limit
+on the memory used by reduction scripts.
+"""
+
+import time
+import tests.utils.db as db_utils
+
+
+class TestAutoreducerTimeLimit:
+    user = "InstrumentScientist"
+    pwd = "InstrumentScientist"
+    instrument = "nom"
+    IPTS = "IPTS-1001"
+    run_number = 10002
+
+    def test_reduction_script_exceeds_time_limit(self, db_connection, request_page):
+        """test that the reduction is terminated and an error is logged"""
+        run_id = db_utils.add_instrument_data_run(db_connection, self.instrument, self.IPTS, self.run_number)
+        db_utils.clear_previous_runstatus(db_connection, run_id)
+
+        # login and send reduction request
+        response = request_page("/report/nom/10002/reduce/", self.user, self.pwd)
+        assert response.status_code == 200
+        assert response.url.endswith("/report/nom/10002/")
+
+        # wait for reduction job to be terminated and database to be updated
+        # note: the post-processing task time limit is set to 6 seconds, since if it is too short,
+        # the memory limit test will hit the time limit before it hits the memory limit
+        time.sleep(7.0)
+
+        assert db_utils.check_run_status_exist(db_connection, run_id, "REDUCTION.REQUEST")
+        assert db_utils.check_run_status_exist(db_connection, run_id, "REDUCTION.STARTED")
+        assert db_utils.check_run_status_exist(db_connection, run_id, "REDUCTION.DATA_READY")
+        assert db_utils.check_run_status_exist(db_connection, run_id, "REDUCTION.ERROR")
+
+        assert db_utils.check_error_msg_contains(db_connection, run_id, "Time limit exceeded")


### PR DESCRIPTION
# Description of the changes

Advance the Post-Processing Agent version to 3.4.0 and add a system test for the new time limit on autoreduction jobs.

Check all that apply:
- [ ] ~~updated documentation~~
- [ ] ~~Source added/refactored~~
- [ ] ~~Added unit tests~~
- [x] Added integration tests

**References:**
- Links to IBM EWM items: [Story 9317: [post-processing agent] Autoreduction job time limit](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9317)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
