### PR TITLE
Temporary change: list only runs from the last 2 hours

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -966,7 +966,7 @@ def get_live_runs_update(request, instrument_id, ipts_id, **data_dict):
     return data_dict
 
 
-def get_live_runs(timeframe=12, number_of_entries=25, instrument_id=None, as_html=True):
+def get_live_runs(timeframe=2, number_of_entries=10, instrument_id=None, as_html=True):
     """
     Get recent runs for all instruments.
     If no run is found in the last few hours (defined by the timeframe parameter),


### PR DESCRIPTION
# Description of the changes

Change the horizon for last runs from 12 hours to 2 hours as part of troubleshooting WebMon sluggish performance and error messages.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 9840: [EPIC] WebMon DB connection errors causing poor performance](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9840)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
