### PR TITLE
Switch from querying separately for each run to all at the same time when determining run status text

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -931,8 +931,9 @@ def get_live_runs_update(request, instrument_id, ipts_id, **data_dict):
     update_list = []
     if since_run_id is not None and len(run_list) > 0:
         data_dict["last_run_id"] = run_list[0].id
+        run_status_text_dict = report_view_util.get_run_status_text_dict(run_list)
         for r in run_list:
-            status = report_view_util.get_run_status_text(r)
+            status = run_status_text_dict.get(r.id, "unknown")
 
             run_dict = {
                 "key": "run_id_%s" % str(r.id),


### PR DESCRIPTION
# Description of the changes

Instead of making a separate query to `WorkflowSummary`, `RunStatus` and `Error` for every `DataRun` we just make those queries for all runs at the same time. This should dramatically reduce the number of calls to the database.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
