### PR TITLE
Reduce the scope of the atomic so other code can wait less time

### DIFF
--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -262,7 +262,6 @@ def retrieve_rates(instrument_id, last_run_id):
     return runs, errors
 
 
-@transaction.atomic
 def run_rate(instrument_id, n_hours=24):
     """
     Returns the rate of new runs for the last n_hours hours.
@@ -273,13 +272,15 @@ def run_rate(instrument_id, n_hours=24):
     # Try calling the stored procedure (faster)
     msg = ""  # start with empty message to help with logging
     try:
-        cursor = connection.cursor()
-        cursor.callproc("run_rate", (instrument_id.id,))
-        msg = cursor.fetchone()[0]
-        cursor.execute('FETCH ALL IN "%s"' % msg)
-        rows = cursor.fetchall()
-        cursor.close()
-        return [[int(r[0]), int(r[1])] for r in rows]
+        # Try calling the stored procedure (faster)
+        with transaction.atomic():
+            cursor = connection.cursor()
+            cursor.callproc("run_rate", (instrument_id.id,))
+            msg = cursor.fetchone()[0]
+            cursor.execute('FETCH ALL IN "%s"' % msg)
+            rows = cursor.fetchall()
+            cursor.close()
+        return [[int(row[0]), int(row[1])] for row in rows]
     except Exception:
         connection.close()
         logging.exception("Call to stored procedure run_rate(%s) failed", str(instrument_id))
@@ -303,7 +304,6 @@ def run_rate(instrument_id, n_hours=24):
         raise
 
 
-@transaction.atomic
 def error_rate(instrument_id, n_hours=24):
     """
     Returns the rate of errors for the last n_hours hours.
@@ -314,13 +314,15 @@ def error_rate(instrument_id, n_hours=24):
     # Try calling the stored procedure (faster)
     msg = ""  # start with empty message to help with logging
     try:
-        cursor = connection.cursor()
-        cursor.callproc("error_rate", (instrument_id.id,))
-        msg = cursor.fetchone()[0]
-        cursor.execute('FETCH ALL IN "%s"' % msg)
-        rows = cursor.fetchall()
-        cursor.close()
-        return [[int(r[0]), int(r[1])] for r in rows]
+        # Try calling the stored procedure (faster)
+        with transaction.atomic():
+            cursor = connection.cursor()
+            cursor.callproc("error_rate", (instrument_id.id,))
+            msg = cursor.fetchone()[0]
+            cursor.execute('FETCH ALL IN "%s"' % msg)
+            rows = cursor.fetchall()
+            cursor.close()
+        return [[int(row[0]), int(row[1])] for row in rows]
     except Exception:
         connection.close()
         logging.exception("Call to stored procedure error_rate(%s) failed", str(instrument_id))


### PR DESCRIPTION
This reduces the scope of `transaction.atomic` ([docs](https://docs.djangoproject.com/en/5.1/topics/db/transactions/#controlling-transactions-explicitly)) when generating the run rate for the little dashboard charts. In principle, this allows other code to interact with the database sooner and will help the performance of the website. In practice, I doubt it will make a noticeable difference.

The only other place using `trasaction.atomic` is [`database.transactions.add_status_entry()`](https://github.com/neutrons/data_workflow/blob/8d5f1bcbc7d09cce8451361679ac163b321b34e0/src/workflow_app/workflow/database/transactions.py#L31).


Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
