### PR TITLE
More performance improvements

### DIFF
--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -104,7 +104,7 @@ def expert_status(request):
     global_status_url = reverse(settings.LANDING_VIEW, args=[])
 
     template_values = {
-        "instruments": view_util.get_instrument_status_summary(),
+        "instruments": view_util.get_instrument_status_summary(True),
         "breadcrumbs": "<a href='%s'>home</a> &rsaquo; dashboard" % global_status_url,
         "postprocess_status": view_util.get_system_health(),
         "update_url": reverse("dasmon:dashboard_update"),

--- a/src/webmon_app/reporting/templates/dasmon/dashboard.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard.html
@@ -28,8 +28,6 @@
         for (var i=0; i<data.instruments.length; i++)
         {
            global_system_status_update(data, i);
-           var content = "<li class='status_"+data.instruments[i].completeness+"' id='"+data.instruments[i].name+"_completeness'>"+data.instruments[i].completeness_msg+"</td>";
-           $('#'+data.instruments[i].name+'_completeness').replaceWith(content);
         }
         {% for item in data %}
         instrument_rates.{{ item|lower }} = data.instrument_rates.{{ item|lower }};{% endfor %}

--- a/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
+++ b/src/webmon_app/reporting/templates/dasmon/dashboard_simple.html
@@ -17,8 +17,6 @@
         for (var i=0; i<data.instruments.length; i++)
         {
            global_system_status_update(data, i);
-           var content = "<li class='status_"+data.instruments[i].completeness+"' id='"+data.instruments[i].name+"_completeness'>"+data.instruments[i].completeness_msg+"</td>";
-           $('#'+data.instruments[i].name+'_completeness').replaceWith(content);
         }
     }, dataType: "json", timeout: 30000, cache: true,
         statusCode: { 401: function() { new_alert("Your session expired. Please log in again"); show_alert(); }}});

--- a/src/webmon_app/reporting/templates/dasmon/expert_status.html
+++ b/src/webmon_app/reporting/templates/dasmon/expert_status.html
@@ -16,8 +16,6 @@
         for (var i=0; i<data.instruments.length; i++)
         {
            global_system_status_update(data, i);
-           var content = "<li class='status_"+data.instruments[i].completeness+"' id='"+data.instruments[i].name+"_completeness'>"+data.instruments[i].completeness_msg+"</td>";
-           $('#'+data.instruments[i].name+'_completeness').replaceWith(content);
         }
     }, dataType: "json", timeout: 30000, cache: true,
         statusCode: { 401: function() { new_alert("Your session expired. Please log in again"); show_alert(); }}});


### PR DESCRIPTION
# Description of the changes

Following on from #217

The changes implemented in the method `dasmon.view_util.get_run_list` is the same approach as what was done in #127.

The changes to `dasmon.view_util.get_instrument_status_summary` reduces the amount returned to what is needed and therefore greatly reduces the number of database queries. The `completeness` was never used and the `dasmon_status`and `pvstreamer_status` was only used in the "expert" view (https://monitor.sns.gov/dasmon/expert/) that I don't think people know exists because there are no links to it.

The changes should help the performance of all of the dashboards, _e.g._ https://monitor.sns.gov/dasmon/

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
