### PR TITLE
Use context manager to guarantee the db connection is closed

### DIFF
--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -274,15 +274,13 @@ def run_rate(instrument_id, n_hours=24):
     try:
         # Try calling the stored procedure (faster)
         with transaction.atomic():
-            cursor = connection.cursor()
-            cursor.callproc("run_rate", (instrument_id.id,))
-            msg = cursor.fetchone()[0]
-            cursor.execute('FETCH ALL IN "%s"' % msg)
-            rows = cursor.fetchall()
-            cursor.close()
+            with connection.cursor() as cursor:
+                cursor.callproc("run_rate", (instrument_id.id,))
+                msg = cursor.fetchone()[0]
+                cursor.execute('FETCH ALL IN "%s"' % msg)
+                rows = cursor.fetchall()
         return [[int(row[0]), int(row[1])] for row in rows]
     except Exception:
-        connection.close()
         logging.exception("Call to stored procedure run_rate(%s) failed", str(instrument_id))
         logging.error("Running query from python")
 
@@ -316,15 +314,13 @@ def error_rate(instrument_id, n_hours=24):
     try:
         # Try calling the stored procedure (faster)
         with transaction.atomic():
-            cursor = connection.cursor()
-            cursor.callproc("error_rate", (instrument_id.id,))
-            msg = cursor.fetchone()[0]
-            cursor.execute('FETCH ALL IN "%s"' % msg)
-            rows = cursor.fetchall()
-            cursor.close()
+            with connection.cursor() as cursor:
+                cursor.callproc("error_rate", (instrument_id.id,))
+                msg = cursor.fetchone()[0]
+                cursor.execute('FETCH ALL IN "%s"' % msg)
+                rows = cursor.fetchall()
         return [[int(row[0]), int(row[1])] for row in rows]
     except Exception:
-        connection.close()
         logging.exception("Call to stored procedure error_rate(%s) failed", str(instrument_id))
         logging.error("Running query from python")
 


### PR DESCRIPTION
Switch to a context manager rather than explicitly closing the database connection. This should make it more reliable on errors.


Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
