### PR TITLE
Don't allow editing MonitoredVariable from table

### DIFF
--- a/src/webmon_app/reporting/pvmon/admin.py
+++ b/src/webmon_app/reporting/pvmon/admin.py
@@ -1,32 +1,6 @@
 from reporting.pvmon.models import PVName, PV, PVCache, PVString, PVStringCache, MonitoredVariable
 from django.contrib import admin
-from django import forms
-from django.core.exceptions import ValidationError
 import datetime
-
-
-class PVNameCharField(forms.fields.CharField):
-    def to_python(self, value):
-        if isinstance(value, PVName):
-            return value
-
-        if value is None:
-            return value
-
-        try:
-            return PVName.objects.get(name=value)
-        except PVName.DoesNotExist:
-            raise ValidationError("PvName does not exist")
-
-
-class AddForm(forms.ModelForm):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["pv_name"] = PVNameCharField()
-
-    class Meta:
-        model = MonitoredVariable
-        exclude = ()
 
 
 class PVAdmin(admin.ModelAdmin):
@@ -54,8 +28,6 @@ class PVNameAdmin(admin.ModelAdmin):
 
 class MonitoredVariableAdmin(admin.ModelAdmin):
     list_display = ("id", "instrument", "pv_name", "rule_name")
-    list_editable = ("pv_name", "rule_name")
-    form = AddForm
 
 
 admin.site.register(PVName, PVNameAdmin)


### PR DESCRIPTION
This removes the ability to edit the MonitoredVariable from http://localhost/database/pvmon/monitoredvariable/. This was causing it to load to slow and to timeout as it was creating a dropdown for PVName for every row (there are 100 rows per page) that had ~23000 items in it. Django did this really inefficiently.

You can still edit the entry by first selecting the ID number, _e.g._ http://localhost/database/pvmon/monitoredvariable/9/change/. I also removed the custom form for adding and editing (http://localhost/database/pvmon/monitoredvariable/add/), this allows the dropdown to be created there but since it is just for a single entry it will be fast.

# Description of the changes


Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [9478: [WebMon] Django admin interface Internal Server Error when viewing Monitored Variables](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9478)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
