### PR TITLE
Include "low-res"  reduction options for instrument REF_M

### DIFF
--- a/src/webmon_app/reporting/reduction/forms.py
+++ b/src/webmon_app/reporting/reduction/forms.py
@@ -323,6 +323,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
     bck_max = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck = forms.BooleanField(required=False, initial=False)
     bck_width = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
+    force_low_res = forms.BooleanField(required=False, initial=False)
+    low_res_min = forms.IntegerField(required=True, initial=20, widget=forms.NumberInput(attrs={"size": "5"}))
+    low_res_max = forms.IntegerField(required=True, initial=236, widget=forms.NumberInput(attrs={"size": "5"}))
 
     # Options for second peak
     force_peak_s2 = forms.BooleanField(required=False, initial=False)
@@ -334,6 +337,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
     bck_max_s2 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck_s2 = forms.BooleanField(required=False, initial=False)
     bck_width_s2 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
+    force_low_res_s2 = forms.BooleanField(required=False, initial=False)
+    low_res_min_s2 = forms.IntegerField(required=True, initial=20, widget=forms.NumberInput(attrs={"size": "5"}))
+    low_res_max_s2 = forms.IntegerField(required=True, initial=236, widget=forms.NumberInput(attrs={"size": "5"}))
 
     # Options for third peak
     force_peak_s3 = forms.BooleanField(required=False, initial=False)
@@ -345,6 +351,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
     bck_max_s3 = forms.IntegerField(required=True, initial=100, widget=forms.NumberInput(attrs={"size": "5"}))
     use_side_bck_s3 = forms.BooleanField(required=False, initial=False)
     bck_width_s3 = forms.IntegerField(required=True, initial=10, widget=forms.NumberInput(attrs={"size": "4"}))
+    force_low_res_s3 = forms.BooleanField(required=False, initial=False)
+    low_res_min_s3 = forms.IntegerField(required=True, initial=20, widget=forms.NumberInput(attrs={"size": "5"}))
+    low_res_max_s3 = forms.IntegerField(required=True, initial=236, widget=forms.NumberInput(attrs={"size": "5"}))
 
     # List of fields are used in the template
     _template_list = [
@@ -365,6 +374,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
         "bck_max",
         "use_side_bck",
         "bck_width",
+        "force_low_res",
+        "low_res_min",
+        "low_res_max",
         # Options for second peak
         "force_peak_s2",
         "peak_min_s2",
@@ -375,6 +387,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
         "bck_max_s2",
         "use_side_bck_s2",
         "bck_width_s2",
+        "force_low_res_s2",
+        "low_res_min_s2",
+        "low_res_max_s2",
         # Options for third peak
         "force_peak_s3",
         "peak_min_s3",
@@ -385,6 +400,9 @@ class ReductionConfigurationREF_MForm(BaseReductionConfigurationForm):
         "bck_max_s3",
         "use_side_bck_s3",
         "bck_width_s3",
+        "force_low_res_s3",
+        "low_res_min_s3",
+        "low_res_max_s3",
     ]
 
 

--- a/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
+++ b/src/webmon_app/reporting/templates/reduction/configuration_ref_m.html
@@ -195,6 +195,20 @@ if you want to use the region on each side of the peak to estimate your backgrou
         </td>
     </tr>
 
+    <!-- Force low-res ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_low_res }}
+            <span title="Override the low resolution (Y-Pixel) range in the sample logs with your own range.
+Check the following box if you want to define your own range and use it for peak selection.">
+                <strong>Force low-res ROI</strong></span>
+            <label class='short_label' for='low_res_min'>Pixel<sub>min</sub></label>
+            {{ options_form.low_res_min }}
+            <label class='short_label' for='low_res_max'>Pixel<sub>max</sub></label>
+            {{ options_form.low_res_max }}
+        </td>
+    </tr>
+
 
     <!-- Divider line -->
     <td><hr></td>
@@ -256,6 +270,20 @@ if you want to use the region on each side of the peak to estimate your backgrou
                 <strong>Use side background</strong>
             </span>
             <label class='long_label' for='bck_width_s2'>Pixels on each side</label> {{ options_form.bck_width_s2 }}
+        </td>
+    </tr>
+
+    <!-- Force low-res ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_low_res_s2 }}
+            <span title="Override the low resolution (Y-Pixel) range in the sample logs with your own range.
+Check the following box if you want to define your own range and use it for peak selection.">
+                <strong>Force low-res ROI</strong></span>
+            <label class='short_label' for='low_res_min_s2'>Pixel<sub>min</sub></label>
+            {{ options_form.low_res_min_s2 }}
+            <label class='short_label' for='low_res_max_s2'>Pixel<sub>max</sub></label>
+            {{ options_form.low_res_max_s2 }}
         </td>
     </tr>
 
@@ -321,6 +349,20 @@ if you want to use the region on each side of the peak to estimate your backgrou
                 <strong>Use side background</strong>
             </span>
             <label class='long_label' for='bck_width_s3'>Pixels on each side</label> {{ options_form.bck_width_s3 }}
+        </td>
+    </tr>
+
+    <!-- Force low-res ROI options -->
+      <tr class='tiny_input'>
+        <td>
+            {{ options_form.force_low_res_s3 }}
+            <span title="Override the low resolution (Y-Pixel) range in the sample logs with your own range.
+Check the following box if you want to define your own range and use it for peak selection.">
+                <strong>Force low-res ROI</strong></span>
+            <label class='short_label' for='low_res_min_s3'>Pixel<sub>min</sub></label>
+            {{ options_form.low_res_min_s3 }}
+            <label class='short_label' for='low_res_max_s3'>Pixel<sub>max</sub></label>
+            {{ options_form.low_res_max_s3 }}
         </td>
     </tr>
 

--- a/src/webmon_app/reporting/tests/test_reduction/test_forms.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_forms.py
@@ -24,6 +24,9 @@ class TestREF_MForm(TestCase):
         "bck_max": 100,
         "use_side_bck": False,
         "bck_width": 10,
+        "force_low_res": False,
+        "low_res_min": 42,
+        "low_res_max": 142,
         # Options for second peak
         "force_peak_s2": False,
         "peak_min_s2": 160,
@@ -34,6 +37,9 @@ class TestREF_MForm(TestCase):
         "bck_max_s2": 100,
         "use_side_bck_s2": False,
         "bck_width_s2": 10,
+        "force_low_res_s2": False,
+        "low_res_min_s2": 42,
+        "low_res_max_s2": 142,
         # Options for third peak
         "force_peak_s3": False,
         "peak_min_s3": 160,
@@ -44,6 +50,9 @@ class TestREF_MForm(TestCase):
         "bck_max_s3": 100,
         "use_side_bck_s3": False,
         "bck_width_s3": 10,
+        "force_low_res_s3": False,
+        "low_res_min_s3": 42,
+        "low_res_max_s3": 142,
     }
 
     def test_empty_form(self):
@@ -75,6 +84,9 @@ class TestREF_MForm(TestCase):
                 "bck_max": "",
                 "use_side_bck": "False",
                 "bck_width": "",
+                "force_low_res": "False",
+                "low_res_min": "",
+                "low_res_max": "",
                 # Options for second peak
                 "force_peak_s2": "False",
                 "peak_min_s2": "",
@@ -85,6 +97,9 @@ class TestREF_MForm(TestCase):
                 "bck_max_s2": "",
                 "use_side_bck_s2": "False",
                 "bck_width_s2": "",
+                "force_low_res_s2": "False",
+                "low_res_min_s2": "",
+                "low_res_max_s2": "",
                 # Options for third peak
                 "force_peak_s3": "False",
                 "peak_min_s3": "",
@@ -95,6 +110,9 @@ class TestREF_MForm(TestCase):
                 "bck_max_s3": "",
                 "use_side_bck_s3": "False",
                 "bck_width_s3": "",
+                "force_low_res_s3": "False",
+                "low_res_min_s3": "",
+                "low_res_max_s3": "",
             },
         )
 

--- a/src/webmon_app/reporting/tests/test_reduction/test_views.py
+++ b/src/webmon_app/reporting/tests/test_reduction/test_views.py
@@ -173,6 +173,9 @@ class TestView(TestCase):
                 "bck_max": 100,
                 "use_side_bck": False,
                 "bck_width": 10,
+                "force_low_res": False,
+                "low_res_min": 42,
+                "low_res_max": 142,
                 # Options for second peak
                 "force_peak_s2": True,
                 "peak_min_s2": 170,
@@ -183,6 +186,9 @@ class TestView(TestCase):
                 "bck_max_s2": 101,
                 "use_side_bck_s2": True,
                 "bck_width_s2": 11,
+                "force_low_res_s2": True,
+                "low_res_min_s2": 91,
+                "low_res_max_s2": 181,
                 # Options for third peak
                 "force_peak_s3": False,
                 "peak_min_s3": 180,
@@ -193,12 +199,15 @@ class TestView(TestCase):
                 "bck_max_s3": 102,
                 "use_side_bck_s3": False,
                 "bck_width_s3": 12,
+                "force_low_res_s3": False,
+                "low_res_min_s3": 66,
+                "low_res_max_s3": 166,
             },
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "reduction/configuration_ref_m.html")
         # uncomment the following line only when debugging, in order to inspect the response content
-        # open("/tmp/junk.html", "wb").write(response.content)  # take a look to file:///tmp/junk.html with the browser
+        open("/tmp/junk.html", "wb").write(response.content)  # take a look to file:///tmp/junk.html with the browser
 
     def test_configuration_change(self):
         # no data

--- a/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py
+++ b/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py
@@ -66,6 +66,8 @@ def reduction_user_options():
         bck_roi=[int(28), int(80)],
         use_tight_bck=False,
         bck_offset=int(),
+        force_low_res=False,
+        low_res_roi=[int(20), int(236)],
     )
 
     # Options for Peak 2
@@ -78,6 +80,8 @@ def reduction_user_options():
         bck_roi=[int(30), int(70)],
         use_tight_bck=_as_bool(False),
         bck_offset=int(),
+        force_low_res=False,
+        low_res_roi=[int(20), int(236)],
     )
 
     # Options for Peak 3
@@ -90,6 +94,8 @@ def reduction_user_options():
         bck_roi=[int(30), int(70)],
         use_tight_bck=_as_bool(False),
         bck_offset=int(),
+        force_low_res=False,
+        low_res_roi=[int(20), int(236)],
     )
 
     # Do we have more than one peak in this run?

--- a/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py.template
+++ b/tests/data/REF_M/shared/autoreduce/reduce_REF_M.py.template
@@ -64,7 +64,9 @@ def reduction_user_options():
         force_bck_roi=_as_bool(${force_background}),
         bck_roi=[int(${bck_min}), int(${bck_max})],
         use_tight_bck=${use_side_bck},
-        bck_offset=int(${bck_width})
+        bck_offset=int(${bck_width}),
+        force_low_res = _as_bool(${force_low_res}),
+        low_res_roi = [int(${low_res_min}), int(${low_res_max})]
     )
 
     # Options for Peak 2
@@ -76,7 +78,9 @@ def reduction_user_options():
         force_bck_roi=_as_bool(${force_background_s2}),
         bck_roi = [int(${bck_min_s2}), int(${bck_max_s2})],
         use_tight_bck=_as_bool(${use_side_bck_s2}),
-        bck_offset=int(${bck_width_s2})
+        bck_offset=int(${bck_width_s2}),
+        force_low_res = _as_bool(${force_low_res_s2}),
+        low_res_roi = [int(${low_res_min_s2}), int(${low_res_max_s2})]
     )
 
     # Options for Peak 3
@@ -89,6 +93,8 @@ def reduction_user_options():
         bck_roi=[int(${bck_min_s3}), int(${bck_max_s3})],
         use_tight_bck=_as_bool(${use_side_bck_s3}),
         bck_offset=int(${bck_width_s3}),
+        force_low_res = _as_bool(${force_low_res_s3}),
+        low_res_roi = [int(${low_res_min_s3}), int(${low_res_max_s3})]
     )
 
     # Do we have more than one peak in this run?
@@ -130,7 +136,7 @@ def main():
     file_path = args.report_file
     if file_path and os.path.basename(file_path) == file_path:
         file_path = os.path.join(args.outdir, file_path)
-    run_number = re.search(r'REF_M_\d+', args.events_file).group(0)
+    run_number = re.search(r'REF_M_(\d+)', args.events_file).group(1)
     upload_html_report(reports, publish=(not args.no_publish), run_number=run_number, report_file=file_path)
 
     # Check if the auto-reduce data has been saved to the canonical IPTS-XXXXX/shared/autoreduce directory


### PR DESCRIPTION
# Description of the changes


Check all that apply:
- [ ] ~updated documentation~
- [x] Source added/refactored
- [x] refactored unit tests
- [ ] ~Added integration tests~

**References:**
- Links to IBM EWM items: [10054](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10054)

# Manual test for the reviewer
[Build a local development](https://data-workflow.readthedocs.io/en/latest/developer/instruction/build.html#building-a-local-deployment) and make sure the low-res options show up in the reduction settings for REF_M page http://localhost/reduction/ref_m/

<img src="https://github.com/user-attachments/assets/a9056e6b-fb5a-4bc8-a555-756949218a00" width=400>

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
