### PR TITLE
Add new indexes for created_on and add add_indices command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ configure/webmon: install/webmon
 	# add the stored sql proceedures
 	python $(MANAGE_PY_WEBMON) add_stored_procs
 
+	# add indexes
+	python $(MANAGE_PY_WEBMON) add_indices
+
 	@echo "\n\nReady to go\n"
 
 configure/load_initial_data: install/webmon

--- a/src/webmon_app/reporting/dasmon/sql/indices.sql
+++ b/src/webmon_app/reporting/dasmon/sql/indices.sql
@@ -1,7 +1,7 @@
 -- Index: dasmon_statusvariable_time_key
 -- DROP INDEX dasmon_statusvariable_time_key;
 
-CREATE INDEX dasmon_statusvariable_time_key
+CREATE INDEX IF NOT EXISTS dasmon_statusvariable_time_key
   ON dasmon_statusvariable
   USING btree
   (instrument_id_id , key_id_id , "timestamp" );

--- a/src/webmon_app/reporting/pvmon/sql/indices.sql
+++ b/src/webmon_app/reporting/pvmon/sql/indices.sql
@@ -1,7 +1,7 @@
 -- Index: pvmon_pv_time_key
 -- DROP INDEX pvmon_pv_time_key;
 
-CREATE INDEX pvmon_pv_time_key
+CREATE INDEX IF NOT EXISTS pvmon_pv_time_key
   ON pvmon_pv
   USING btree
   (instrument_id , name_id , update_time );

--- a/src/webmon_app/reporting/report/management/commands/add_indices.py
+++ b/src/webmon_app/reporting/report/management/commands/add_indices.py
@@ -1,0 +1,23 @@
+# flake8: noqa: F401
+from django.core.management.base import BaseCommand
+from django.db import connection
+from pathlib import Path
+
+# from report/sql/indices.sql
+report_indices = Path(__file__).resolve(strict=True).parent.parent.parent / "sql" / "indices.sql"
+
+# from pvmon/sql/indices.sql
+pvmon_indices = Path(__file__).resolve(strict=True).parent.parent.parent.parent / "pvmon" / "sql" / "indices.sql"
+
+# from dasmon/sql/indices.sql
+dasmon_indices = Path(__file__).resolve(strict=True).parent.parent.parent.parent / "dasmon" / "sql" / "indices.sql"
+
+
+class Command(BaseCommand):
+    help = "add additional indexes to backend database"
+
+    def handle(self, *args, **options):
+        with connection.cursor() as cursor:
+            cursor.execute(open(report_indices).read())
+            cursor.execute(open(pvmon_indices).read())
+            cursor.execute(open(dasmon_indices).read())

--- a/src/webmon_app/reporting/report/sql/indices.sql
+++ b/src/webmon_app/reporting/report/sql/indices.sql
@@ -1,7 +1,7 @@
 -- Index: report_runstatus_time_run
 -- DROP INDEX report_runstatus_time_run;
 
-CREATE INDEX report_runstatus_time_run
+CREATE INDEX IF NOT EXISTS report_runstatus_time_run
   ON report_runstatus
   USING btree
   (run_id_id , created_on );
@@ -10,7 +10,18 @@ CREATE INDEX report_runstatus_time_run
 -- Index: report_runstatus_time_id
 -- DROP INDEX report_runstatus_time_id;
 
-CREATE INDEX report_runstatus_time_id
+CREATE INDEX IF NOT EXISTS report_runstatus_time_id
   ON report_runstatus
   USING btree
   (id , created_on );
+
+
+CREATE INDEX IF NOT EXISTS report_runstatus_created_on
+  ON report_runstatus
+  USING btree
+  (created_on);
+
+CREATE INDEX IF NOT EXISTS report_datarun_created_on
+  ON report_datarun
+  USING btree
+  (created_on);


### PR DESCRIPTION
# Description of the changes

* Add a new command to execute the additional indices and run it from the Makefile
* Add two new indexes to speed up the `run_rate` and `error_rate` stored procedures when filtering on `created_on`.

You can verify that the new indexes are added to the database by running the following commands

first connect to the database
```bash
docker exec -it data_workflow-db-1 psql -U workflow
```

then run
```sql
SELECT tablename, indexname, indexdef FROM pg_indexes WHERE tablename = 'report_runstatus';
SELECT tablename, indexname, indexdef FROM pg_indexes WHERE tablename = 'report_datarun';
```

and check for `report_runstatus_created_on` and `report_datarun_created_on`.

I've seen `error_rate` and `run_rate` run up to 100 times faster with the new indexes.

The previous indexes in the `indices.sql` files are already in the production database.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [9972: [WebMon] Extended dashboard SQL query errors](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9972)
- Links to related issues or pull requests:

# Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
