### PR TITLE
Changes for nginx to support robots.txt and other standard files

### DIFF
--- a/nginx/django.conf
+++ b/nginx/django.conf
@@ -49,8 +49,27 @@ server {
   location /stats/nginx {
     stub_status on;
   }
-}
 
+  location = /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-agent: *\nDisallow: /\n";
+  }
+
+  location = /apple-touch-icon.png {
+    alias /var/www/workflow/static/apple-touch-icon.png;
+    expires 30d;
+  }
+
+  location = /apple-touch-icon-precomposed.png {
+    alias /var/www/workflow/static/apple-touch-icon-precomposed.png;
+    expires 30d;
+  }
+
+  location ^~ /.well-known/ {
+    return 404;
+  }
+
+}
 
 server {
 

--- a/nginx/django.conf
+++ b/nginx/django.conf
@@ -66,7 +66,8 @@ server {
   }
 
   location ^~ /.well-known/ {
-    return 404;
+    add_header Content-Type text/plain;
+    return 404 'Not found\n';
   }
 
 }


### PR DESCRIPTION
# Description of the changes

This PR updates the Nginx configuration (`nginx/django.conf`) to handle requests for several standard web files, reducing the number of "Not Found" warnings in the Django logs. Specifically, it adds Nginx `location` blocks to:

*   Serve a basic `robots.txt` to disallow all crawlers.
*   Serve `apple-touch-icon.png` and `apple-touch-icon-precomposed.png` from the static files directory with appropriate caching headers.
*   Return a `404 Not Found` for any requests under the `/.well-known/` path, preventing these requests from hitting the Django application.

A significant amount of effort during this work involved setting up and debugging the local development environment, particularly ensuring the Pytest suite ran correctly, although no test code itself was modified.

Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM 9994](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9994)
- Links to related issues or pull requests: N/A?
# Manual test for the reviewer

1.  Ensure the services are running (`docker compose up -d`). You might need to restart Nginx if it was already running: `docker compose restart nginx`.
2.  Verify the new Nginx locations using `curl` (replace `localhost` if your setup uses a different hostname/IP):
    *   `curl -i http://localhost/robots.txt`
        *   *Expected:* `HTTP/1.1 200 OK`, `Content-Type: text/plain`, and the body `User-agent: * Disallow: /`
    *   `curl -I http://localhost/apple-touch-icon.png`
        *   *Expected:* `HTTP/1.1 200 OK`, `Content-Type: image/png`, `Expires` header indicating a future date.
    *   `curl -I http://localhost/apple-touch-icon-precomposed.png`
        *   *Expected:* `HTTP/1.1 200 OK`, `Content-Type: image/png`, `Expires` header indicating a future date.
    *   `curl -i http://localhost/.well-known/some-file`
        *   *Expected:* `HTTP/1.1 404 Not Found`
3.  Monitor the `webmon` logs (`docker compose logs -f webmon`). Confirm that requests to these specific paths no longer generate Django "Not Found" warnings.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent