### PR TITLE
Fix variable selector

### DIFF
--- a/src/webmon_app/reporting/static/live_update.js
+++ b/src/webmon_app/reporting/static/live_update.js
@@ -10,8 +10,8 @@ function update_from_ajax_data(data){
         if (data.variables[i].key=='count_rate')
             $('#count_rate_top').replaceWith("<span id='count_rate_top'>"+data.variables[i].value+"</span>");
 
-        $('#'+data.variables[i].key).replaceWith("<span id='"+data.variables[i].key+"'>"+data.variables[i].value+"</span>");
-        $('#'+data.variables[i].key+'_timestamp').replaceWith("<span id='"+data.variables[i].key+"_timestamp'>"+data.variables[i].timestamp+"</span>");
+        $('#'+$.escapeSelector(data.variables[i].key)).replaceWith("<span id='"+data.variables[i].key+"'>"+data.variables[i].value+"</span>");
+        $('#'+$.escapeSelector(data.variables[i].key)+'_timestamp').replaceWith("<span id='"+data.variables[i].key+"_timestamp'>"+data.variables[i].timestamp+"</span>");
     }
     $('#workflow_status').replaceWith("<li class='status_"+data.das_status.workflow+"' id='workflow_status'>Workflow</li>");
 }


### PR DESCRIPTION
# Description of the changes

Because jQuery uses CSS syntax for selecting elements some characters are interpreted as CSS notation. This is happening with PVs that contain things like `:last`, `:first`, `:event`, _etc_.

This is not just an issue for venus but others as well, _e.g._

https://monitor.sns.gov/pvmon/venus/
https://monitor.sns.gov/pvmon/vis/
https://monitor.sns.gov/pvmon/usans/

The fix is simple, you escape any characters with special meaning using [jQuery.escapeSelector](https://api.jquery.com/jQuery.escapeSelector/).


Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [11288: [WebMon] PV plot not shown for VENUS PV:s](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/11288)
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer


To test this you can try in browser, using chrome you can go to https://monitor.sns.gov/pvmon/venus/ and go to `Inspect` -> `Sources` -> `live_update.js` then copy and save these changes and it should now work.

![2025-05-28-153106_1688x1076_scrot](https://github.com/user-attachments/assets/981c7cbf-b7a7-4c7a-8aed-a723760dce52)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
