### PR TITLE
Remove `postgresql` from the conda environment

### DIFF
--- a/conda_environment.yml
+++ b/conda_environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - gunicorn
   - make
   - oauthlib
-  - postgresql
   - psycopg2-binary=2.9.3
   - psutil
   - python-ldap>=3.1

--- a/src/dasmon_app/docker-entrypoint.sh
+++ b/src/dasmon_app/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # wait for postgress to be available
-until PGPASSWORD=${DATABASE_PASS} psql -h "${DATABASE_HOST}" -U "${DATABASE_USER}" -d "${DATABASE_NAME}" -c '\q'; do
+until python -c "import psycopg2; import os; psycopg2.connect(host=os.environ['DATABASE_HOST'], dbname=os.environ['DATABASE_NAME'], user=os.environ['DATABASE_USER'], password=os.environ['DATABASE_PASS']).close()"; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done

--- a/src/webmon_app/docker-entrypoint.sh
+++ b/src/webmon_app/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 MANAGE_PY_WEBMON="/opt/conda/lib/python3.11/site-packages/reporting/manage.py"
 
 # wait for postgress to be available
-until PGPASSWORD=${DATABASE_PASS} psql -h "${DATABASE_HOST}" -U "${DATABASE_USER}" -d "${DATABASE_NAME}" -c '\q'; do
+until python -c "import psycopg2; import os; psycopg2.connect(host=os.environ['DATABASE_HOST'], dbname=os.environ['DATABASE_NAME'], user=os.environ['DATABASE_USER'], password=os.environ['DATABASE_PASS']).close()"; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done

--- a/src/workflow_app/docker-entrypoint.sh
+++ b/src/workflow_app/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # wait for postgress to be available
-until PGPASSWORD=${DATABASE_PASS} psql -h "${DATABASE_HOST}" -U "${DATABASE_USER}" -d "${DATABASE_NAME}" -c '\q'; do
+until python -c "import psycopg2; import os; psycopg2.connect(host=os.environ['DATABASE_HOST'], dbname=os.environ['DATABASE_NAME'], user=os.environ['DATABASE_USER'], password=os.environ['DATABASE_PASS']).close()"; do
   >&2 echo "Postgres is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
# Description of the changes

This change came about because the security vulnerability scans found a bad version of `postgresql` in a conda environment in the Workflow Manager test environment. However, we shouldn't (?) need to install the whole database system to run Workflow Manager and other services accessing the database, only `psycopg2` is needed.
Note that Workflow DB gets PostgreSQL from the postgres docker image.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
