### PR TITLE
Ensure self signed certificate gets added to ca-bundle for autoreducers

### DIFF
--- a/Dockerfile.autoreducer
+++ b/Dockerfile.autoreducer
@@ -34,8 +34,8 @@ RUN pip3 install requests beautifulsoup4
 # Install plot_publisher from GitHub (modernize-codebase-v0.2.0 branch with Python 3.9 support)
 RUN pip3 install git+https://github.com/neutrons/plot_publisher.git@modernize-codebase-v0.2.0
 
-# Copy SSL certificate for livedata server communication
-COPY nginx/nginx.crt /etc/ssl/certs/nginx.crt
+# Updating certificates to add self-signed certificate for local testing
+RUN update-ca-trust
 
 # Install specific plotly version based on build arg
 RUN if [ "$PLOTLY_VERSION" = "5" ]; then \
@@ -65,4 +65,4 @@ RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
     chmod +x /usr/bin/run_postprocessing
 
 # start the service
-CMD run_postprocessing
+CMD ["run_postprocessing"]

--- a/Makefile
+++ b/Makefile
@@ -53,18 +53,21 @@ check: ## Check python dependencies
 wheel/dasmon: ## create or update python wheel for service "dasmon". Clean up build/ first
 	cd src/dasmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/dasmon_app && python -m build --no-isolation --wheel
+	cd src/dasmon_app && echo dist/django_nscd_dasmon-*.whl
 	# verify it is correct
 	cd src/dasmon_app && check-wheel-contents dist/django_nscd_dasmon-*.whl
 
 wheel/webmon: ## create or update python wheel for service "webmon". Clean up build/ first
 	cd src/webmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/webmon_app && python -m build --no-isolation --wheel
+	cd src/webmon_app && echo dist/django_nscd_webmon-*.whl
 	# verify it is correct - ignoring duplicate file check
 	cd src/webmon_app && check-wheel-contents dist/django_nscd_webmon-*.whl
 
 wheel/workflow: ## create or update python wheel for service "workflow". Clean up build/ first
 	cd src/workflow_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/workflow_app && python -m build --no-isolation --wheel
+	cd src/workflow_app && echo dist/django_nscd_workflow-*.whl
 	# verify it is correct
 	cd src/workflow_app && check-wheel-contents dist/django_nscd_workflow-*.whl
 

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ ssl/clean:  ## delete the self-signed ssl certificates for livedata server
 	rm -f nginx/nginx.crt nginx/nginx.key
 
 nginx/nginx.crt nginx/nginx.key:
-	openssl req -x509 -out nginx/nginx.crt -keyout nginx/nginx.key -newkey rsa:2048 -nodes -sha256 --config nginx/san.cnf
+	openssl req -x509 -out nginx/nginx.crt -keyout nginx/nginx.key -newkey rsa:2048 -nodes -sha256 -addext "basicConstraints=CA:TRUE" --config nginx/san.cnf
 
 localdev/up:  ## create images and start containers for local development. Doesn't update python wheels, though.
 	docker compose --file docker-compose.yml up --build

--- a/Makefile
+++ b/Makefile
@@ -53,23 +53,21 @@ check: ## Check python dependencies
 wheel/dasmon: ## create or update python wheel for service "dasmon". Clean up build/ first
 	cd src/dasmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/dasmon_app && python -m build --no-isolation --wheel
-	cd src/dasmon_app && echo dist/django_nscd_dasmon-*.whl
 	# verify it is correct
-	cd src/dasmon_app && check-wheel-contents dist/django_nscd_dasmon-*.whl
+	cd src/dasmon_app && check-wheel-contents dist/$(ls dist | grep django_nscd_dasmon)
 
 wheel/webmon: ## create or update python wheel for service "webmon". Clean up build/ first
 	cd src/webmon_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/webmon_app && python -m build --no-isolation --wheel
-	cd src/webmon_app && echo dist/django_nscd_webmon-*.whl
 	# verify it is correct - ignoring duplicate file check
-	cd src/webmon_app && check-wheel-contents dist/django_nscd_webmon-*.whl
+	cd src/webmon_app && check-wheel-contents dist/$(ls dist | grep django_nscd_webmon)
 
 wheel/workflow: ## create or update python wheel for service "workflow". Clean up build/ first
 	cd src/workflow_app && if [ -d "build" ]; then chmod u+rwx -R build && rm -rf build/;fi
 	cd src/workflow_app && python -m build --no-isolation --wheel
 	cd src/workflow_app && echo dist/django_nscd_workflow-*.whl
 	# verify it is correct
-	cd src/workflow_app && check-wheel-contents dist/django_nscd_workflow-*.whl
+	cd src/workflow_app && check-wheel-contents dist/$(ls dist | grep django_nscd_workflow)
 
 wheel/all:  wheel/clean wheel/dasmon wheel/webmon wheel/workflow ## create python wheels for all services. Clean up build/ first
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,12 +126,13 @@ services:
       args:
         CONFIG_FILE: ./tests/configuration/post_process_consumer.conf
         PLOTLY_VERSION: "5"
+    volumes:
+      # add in RHEL9 certs folder to be picked up by update-ca-trust in docker entrypoint
+      - ./nginx/nginx.crt:/etc/pki/ca-trust/source/anchors/nginx.crt
     hostname: autoreducer
     environment:
       - PLOTLY_VERSION=5
-      - SSL_CERT_FILE=/etc/ssl/certs/nginx.crt
-      - PYTHONHTTPSVERIFY=0
-      - CURL_CA_BUNDLE=""
+      - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
     healthcheck:
       test: ["CMD", "pgrep", "queueProcessor"]
     depends_on:
@@ -149,12 +150,13 @@ services:
       args:
         CONFIG_FILE: ./tests/configuration/post_process_consumer.himem.conf
         PLOTLY_VERSION: "6"
+    volumes:
+      # add in RHEL9 certs folder to be picked up by update-ca-trust in docker entrypoint
+      - ./nginx/nginx.crt:/etc/pki/ca-trust/source/anchors/nginx.crt
     hostname: autoreducer.himem
     environment:
       - PLOTLY_VERSION=6
-      - SSL_CERT_FILE=/etc/ssl/certs/nginx.crt
-      - PYTHONHTTPSVERIFY=0
-      - CURL_CA_BUNDLE=""
+      - REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
     healthcheck:
       test: ["CMD", "pgrep", "queueProcessor"]
     depends_on:


### PR DESCRIPTION
# Description of the changes

- add `"basicConstraints=CA:TRUE"` when creating the self-signed certificate
- add the self-signed certificate as a volume into the autoreducers
- add call to `update-ca-trust` to add the self-signed certificate to the ca-bundle

https://unix.stackexchange.com/questions/525601/update-ca-trust-extract-not-adding-certificates-to-ca-bundle

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
