### PR TITLE
Update certificates in the startup script

### DIFF
--- a/Dockerfile.autoreducer
+++ b/Dockerfile.autoreducer
@@ -34,9 +34,6 @@ RUN pip3 install requests beautifulsoup4
 # Install plot_publisher from GitHub (modernize-codebase-v0.2.0 branch with Python 3.9 support)
 RUN pip3 install git+https://github.com/neutrons/plot_publisher.git@modernize-codebase-v0.2.0
 
-# Updating certificates to add self-signed certificate for local testing
-RUN update-ca-trust
-
 # Install specific plotly version based on build arg
 RUN if [ "$PLOTLY_VERSION" = "5" ]; then \
         pip3 install plotly==5.17.0; \
@@ -58,7 +55,9 @@ RUN touch /opt/postprocessing/scripts/oncat_ingest.py && \
     touch /opt/postprocessing/scripts/oncat_reduced_ingest.py
 
 # create startup script
+# add updating certificates to add self-signed certificate for local testing
 RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
+    echo "update-ca-trust" >> /usr/bin/run_postprocessing && \
     echo "/opt/postprocessing/queueProcessor.py &" >> /usr/bin/run_postprocessing && \
     echo "sleep 1" >> /usr/bin/run_postprocessing && \
     echo "tail -F /opt/postprocessing/log/postprocessing.log" >> /usr/bin/run_postprocessing && \


### PR DESCRIPTION
# Description of the changes

Need to modify when to run `update-ca-trust` since it is not available from the volume during build time.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
