### PR TITLE
Guard against monitored variable with pv_name equal to None

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -969,6 +969,8 @@ def get_signals(instrument_id):
     try:
         monitored = MonitoredVariable.objects.filter(instrument=instrument_id)
         for item in monitored:
+            if item.pv_name is None:
+                continue
             try:
                 latests = PVCache.objects.filter(instrument=instrument_id, name=item.pv_name)
                 if len(latests) == 0:
@@ -987,10 +989,11 @@ def get_signals(instrument_id):
             data = pvmon_view_util.get_live_variables(request=None, instrument_id=instrument_id, key_id=item.pv_name)
             data_list = []
             try:
-                for point in data[0][1]:
-                    data_list.append("%g:%g" % (point[0], point[1]))
+                if data is not None and len(data) > 0 and len(data[0]) > 1:
+                    for point in data[0][1]:
+                        data_list.append("%g:%g" % (point[0], point[1]))
             except:  # noqa: E722
-                logger.exception()
+                logger.exception(f"Error processing data for {instrument_id} {item.pv_name}:")
             sig_entry.data = ",".join(data_list)
             sig_alerts.append(sig_entry)
     except:  # noqa: E722

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
@@ -975,6 +975,41 @@ class ViewUtilTest(TestCase):
                 assert me.name == f"sig_{i}"
                 assert f"msg_{i}" in me.status
 
+    def test_get_signals_when_has_monitored_variable_none(self):
+        from reporting.dasmon.view_util import get_signals
+
+        # make instrument
+        inst = Instrument.objects.create(name="testinst_getsignals_no_mon_pvs")
+        inst.save()
+
+        # test with monitored variable with pv_name equal to None
+        MonitoredVariable.objects.create(
+            instrument=inst,
+            pv_name=None,
+            rule_name="",
+        )
+        sig_list = get_signals(inst)
+        assert len(sig_list) == 0
+
+        # test with monitored variables where one is None and one is valid
+        pvname = PVName.objects.create(name="testpv")
+        pvname.save()
+        PVStringCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value="test",
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(
+            instrument=inst,
+            pv_name=pvname,
+            rule_name="",
+        )
+        # test
+        sig_list = get_signals(inst)
+        assert len(sig_list) == 1
+
     def test_get_instrument_status_summary(self):
         from reporting.dasmon.view_util import get_instrument_status_summary
 


### PR DESCRIPTION
# Description of the changes

Add change to handle users adding an empty monitored PV list, which shows up in the database as a monitored PV with `pv_name` equal to None.

In the future, we may want to change how monitored PV:s are added to disallow adding a non-valid value in the table.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [Defect 15172: [WebMon] Monitored variables not appearing on the instrument status page](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15172)
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer
(Instructions for testing here)



# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
