### PR TITLE
Add data acquisition team access to resubmit post-processing jobs

### DIFF
--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -1184,7 +1184,11 @@ def get_instruments_for_user(request):
         try:
             if request.user is not None and hasattr(request.user, "ldap_user"):
                 groups = request.user.ldap_user.group_names
-                if "sns_%s_team" % instrument_name.lower() in groups or "snsadmin" in groups:
+                if (
+                    "sns_%s_team" % instrument_name.lower() in groups
+                    or "snsadmin" in groups
+                    or "slowcontrols_developers" in groups
+                ):
                     instrument_list.append(instrument_name)
         except:  # noqa: E722
             # Couldn't find the user in the instrument LDAP group

--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -1183,11 +1183,11 @@ def get_instruments_for_user(request):
         # LDAP groups
         try:
             if request.user is not None and hasattr(request.user, "ldap_user"):
+                from reporting.users.view_util import GLOBAL_PRIVILEGED_LDAP_GROUPS
+
                 groups = request.user.ldap_user.group_names
-                if (
-                    "sns_%s_team" % instrument_name.lower() in groups
-                    or "snsadmin" in groups
-                    or "slowcontrols_developers" in groups
+                if "sns_%s_team" % instrument_name.lower() in groups or any(
+                    privileged_group in groups for privileged_group in GLOBAL_PRIVILEGED_LDAP_GROUPS
                 ):
                     instrument_list.append(instrument_name)
         except:  # noqa: E722

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
@@ -1092,16 +1092,29 @@ class ViewUtilTest(TestCase):
     def test_get_instruments_for_user(self):
         from reporting.dasmon.view_util import get_instruments_for_user
 
-        # make entries
+        # Test Django group membership
         gp_name = "TESTINST" + settings.INSTRUMENT_TEAM_SUFFIX
         gp = Group.objects.create(name=gp_name)
         gp.save()
-        # mock request
         request = mock.MagicMock()
         request.user.groups.all.return_value = [Group.objects.get(name=gp_name)]
-        # test
         inst_list = get_instruments_for_user(request)
         assert inst_list[0] == "TESTINST"
+
+        # Test LDAP group membership - slowcontrols_developers should see all instruments
+        request = mock.MagicMock()
+        request.user.groups.all.return_value = []
+        ldap_user = mock.MagicMock()
+        ldap_user.group_names = ["slowcontrols_developers"]
+        request.user.ldap_user = ldap_user
+        inst_list = get_instruments_for_user(request)
+        assert "TESTINST" in inst_list
+
+        # Test LDAP group membership - snsadmin should see all instruments
+        ldap_user.group_names = ["snsadmin"]
+        request.user.ldap_user = ldap_user
+        inst_list = get_instruments_for_user(request)
+        assert "TESTINST" in inst_list
 
 
 if __name__ == "__main__":

--- a/src/webmon_app/reporting/tests/test_users/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_users/test_view_util.py
@@ -159,6 +159,12 @@ class TestViews(TestCase):
         ldap_user.group_names = None
         self.assertFalse(view_util.is_instrument_staff(request, "inst"))
 
+        # in slowcontrols_developers group
+        ldap_user = mock.MagicMock()
+        ldap_user.group_names = ["slowcontrols_developers"]
+        user.ldap_user = ldap_user
+        self.assertTrue(view_util.is_instrument_staff(request, "inst"))
+
     def test_is_experiment_member(self):
         # HIDE_RUN_DETAILS = False
         with self.settings(HIDE_RUN_DETAILS=False):
@@ -183,6 +189,13 @@ class TestViews(TestCase):
         # invalid input
         exp.expt_name = 1234
         self.assertFalse(view_util.is_experiment_member(request, "inst", exp))
+
+        # in slowcontrols_developers group
+        ldap_user = mock.MagicMock()
+        ldap_user.group_names = ["slowcontrols_developers"]
+        user.ldap_user = ldap_user
+        exp.expt_name = "IPTS-1234"
+        self.assertTrue(view_util.is_experiment_member(request, "inst", exp))
 
     def test_monitor(self):
         user = User.objects.create_user("user")

--- a/src/webmon_app/reporting/users/view_util.py
+++ b/src/webmon_app/reporting/users/view_util.py
@@ -16,6 +16,9 @@ from django.urls import reverse
 
 from reporting.users.models import PageView
 
+# Global LDAP groups with privileged access across all instruments
+GLOBAL_PRIVILEGED_LDAP_GROUPS = ["snsadmin", "slowcontrols_developers"]
+
 
 def fill_template_values(request, **template_args):
     """
@@ -145,11 +148,11 @@ def is_instrument_staff(request, instrument_id):
     try:
         if request.user is not None and hasattr(request.user, "ldap_user"):
             groups = request.user.ldap_user.group_names
+            # Check instrument-specific groups or global privileged groups
             if (
                 "sns_%s_team" % str(instrument_id).lower() in groups
                 or "hfir_%s_team" % str(instrument_id).lower() in groups
-                or "snsadmin" in groups
-                or "slowcontrols_developers" in groups
+                or any(privileged_group in groups for privileged_group in GLOBAL_PRIVILEGED_LDAP_GROUPS)
             ):
                 return True
     except:  # noqa: E722
@@ -175,8 +178,7 @@ def is_experiment_member(request, instrument_id, experiment_id):
             return (
                 "sns_%s_team" % str(instrument_id).lower() in groups
                 or "sns-ihc" in groups
-                or "snsadmin" in groups
-                or "slowcontrols_developers" in groups
+                or any(privileged_group in groups for privileged_group in GLOBAL_PRIVILEGED_LDAP_GROUPS)
                 or "%s" % experiment_id.expt_name.upper() in groups
                 or is_instrument_staff(request, instrument_id)
             )

--- a/src/webmon_app/reporting/users/view_util.py
+++ b/src/webmon_app/reporting/users/view_util.py
@@ -149,6 +149,7 @@ def is_instrument_staff(request, instrument_id):
                 "sns_%s_team" % str(instrument_id).lower() in groups
                 or "hfir_%s_team" % str(instrument_id).lower() in groups
                 or "snsadmin" in groups
+                or "slowcontrols_developers" in groups
             ):
                 return True
     except:  # noqa: E722
@@ -175,6 +176,7 @@ def is_experiment_member(request, instrument_id, experiment_id):
                 "sns_%s_team" % str(instrument_id).lower() in groups
                 or "sns-ihc" in groups
                 or "snsadmin" in groups
+                or "slowcontrols_developers" in groups
                 or "%s" % experiment_id.expt_name.upper() in groups
                 or is_instrument_staff(request, instrument_id)
             )


### PR DESCRIPTION
## Description of the changes

This PR adds the `slowcontrols_developers` LDAP group to WebMon authorization checks, allowing the data acquisition team to resubmit runs for cataloging and autoreduction.

During the recent filesystem outage, we discovered that the data acquisition team couldn't access run status pages or resubmit post-processing jobs when automatic translation failed. This change gives them the same level of access as instrument teams and snsadmin for all instruments.

**What changed:**
- Added `slowcontrols_developers` to `is_instrument_staff()` LDAP group check
- Added `slowcontrols_developers` to `is_experiment_member()` LDAP group check  
- Added `slowcontrols_developers` to `get_instruments_for_user()` LDAP group check
- Added corresponding unit test cases

**Impact:**
Users in the `slowcontrols_developers` LDAP group can now:
- View run detail pages for all instruments
- Submit post-processing requests (cataloging and autoreduction)
- Access instrument dashboards

Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM-15406](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15406)
- Links to related issues or pull requests: N/A

---

## :warning: Manual test for the reviewer

Since this requires LDAP authentication, full testing needs to happen in the deployed environment:

**With a test user in the `slowcontrols_developers` LDAP group:**

1. Log in to WebMon
2. Navigate to any instrument dashboard (e.g., `/dasmon/arcs/`)
   - Verify the dashboard loads
3. Click on any run to view run details (e.g., `/report/arcs/12345/`)
   - Verify you can see the run details (not the "private data" message)
   - Verify you see the "Resubmit for post-processing" button
4. Navigate to `/report/processing_admin/`
   - Select an instrument and run number
   - Choose "Catalog & reduce" 
   - Submit and verify the request succeeds

**Verify existing permissions still work:**
- Test with a user who is NOT in slowcontrols_developers
- Confirm they still have appropriate access (or lack thereof)

---

## Check list for the reviewer
- [ ] best software practices
    + [x] clearly named variables (better to be verbose in variable names)
    + [x] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [x] code comments added when explaining intent
