### PR TITLE
Fix 500 error when submitting runs without NeXus files for post-processing

### DIFF
--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -14,9 +14,9 @@ import string
 
 import requests
 from django.conf import settings
+from django.contrib import messages
 from django.core.cache import cache
 from django.db import connection, models, transaction
-from django.http import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import formats, timezone
@@ -162,7 +162,7 @@ def send_processing_request(instrument_id, run_id, user=None, destination=None, 
     # If not, look up the online catalog
     file_path = run_id.file
     if len(file_path) == 0:
-        from report.catalog import get_run_info
+        from reporting.report.catalog import get_run_info
 
         run_info = get_run_info(str(instrument_id), "", run_id.run_number)
         for _file in run_info["data_files"]:
@@ -214,10 +214,25 @@ def processing_request(request, instrument, run_id, destination):
     if is_instrument_staff(request, instrument_id):
         try:
             send_processing_request(instrument_id, run_object, request.user, destination=destination)
-        except:  # noqa: E722
+        except RuntimeError as e:
+            # Catalog not found - the Nexus file hasn't been created yet
+            logging.warning("Run not ready for post-processing: %s", str(e))
+            messages.error(
+                request,
+                "This run cannot be submitted for post-processing yet. "
+                "The NeXus data file is not available in the catalog. "
+                "Please wait for the run to be translated to NeXus format or contact the "
+                "data acquisition team if this error persists.",
+            )
+        except Exception:  # noqa: E722
+            # Unexpected error - log and show generic message
             logging.error("Could not send post-processing request: %s", destination)
             logging.exception("")
-            return HttpResponseServerError()
+            messages.error(
+                request,
+                "An unexpected error occurred while submitting the post-processing request. "
+                "Please try again or contact support if the problem persists.",
+            )
     # return render(request, 'report/processing_request_failure.html', {})
     return redirect(reverse("report:detail", args=[instrument, run_id]))
 

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -219,15 +219,13 @@ def processing_request(request, instrument, run_id, destination):
             logging.warning("Run not ready for post-processing: %s", str(e))
             messages.error(
                 request,
-                "This run cannot be submitted for post-processing yet. "
-                "The NeXus data file is not available in the catalog. "
-                "Please wait for the run to be translated to NeXus format or contact the "
+                "This run cannot be submitted for post-processing yet because the data file is not available "
+                "in the catalog. Please wait for the run to complete and the file to be saved, or contact the "
                 "data acquisition team if this error persists.",
             )
-        except Exception:  # noqa: E722
+        except Exception:
             # Unexpected error - log and show generic message
-            logging.error("Could not send post-processing request: %s", destination)
-            logging.exception("")
+            logging.exception("Could not send post-processing request: %s", destination)
             messages.error(
                 request,
                 "An unexpected error occurred while submitting the post-processing request. "

--- a/src/webmon_app/reporting/templates/base.html
+++ b/src/webmon_app/reporting/templates/base.html
@@ -87,7 +87,8 @@
     {% if not forloop.last %}<br>{% endif %}
   {% endfor %}
   </div>
-  {% elif user_alert %}
+  {% endif %}
+  {% if user_alert %}
   <div id="alert_message">
   {% for item in user_alert %}
     {{ item|safe }} {% if not forloop.last %}<br><br>{% endif %}

--- a/src/webmon_app/reporting/templates/base.html
+++ b/src/webmon_app/reporting/templates/base.html
@@ -64,7 +64,7 @@
 </script>
 </head>
 <body>
-{% if user_alert %}
+{% if user_alert or messages %}
 <script id="source" language="javascript" type="text/javascript">
     $(document).ready(show_alert);
 </script>
@@ -80,7 +80,14 @@
 <div class="banner_title">{% block banner %}Data Processing Report{% endblock %}</div>
 
 <div class='user_alert'>
-  {% if user_alert %}
+  {% if messages %}
+  <div id="alert_message">
+  {% for message in messages %}
+    <div class="alert alert-{{ message.tags }}">{{ message }}</div>
+    {% if not forloop.last %}<br>{% endif %}
+  {% endfor %}
+  </div>
+  {% elif user_alert %}
   <div id="alert_message">
   {% for item in user_alert %}
     {{ item|safe }} {% if not forloop.last %}<br><br>{% endif %}

--- a/src/webmon_app/reporting/tests/test_report/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_report/test_view_util.py
@@ -446,7 +446,8 @@ class ViewUtilTest(TestCase):
         messages = list(get_messages(request))
         self.assertEqual(len(messages), 1)
         self.assertIn("cannot be submitted for post-processing yet", str(messages[0]))
-        self.assertIn("NeXus data file is not available", str(messages[0]))
+        self.assertIn("data file is not available in the catalog", str(messages[0]))
+        self.assertIn("wait for the run to complete", str(messages[0]))
 
     @mock.patch("reporting.report.view_util.send_processing_request")
     def test_processing_request_generic_error_shows_generic_message(self, mock_send_request):
@@ -534,7 +535,7 @@ class ViewUtilTest(TestCase):
         """
         from reporting.report.view_util import send_processing_request
 
-        # Setup: Mock catalog to return empty data files (to trigger the import)
+        # Setup: Mock catalog to return data files (to trigger the catalog import path)
         mock_get_run_info.return_value = {
             "data_files": ["/SNS/PG3/IPTS-36301/nexus/PG3_62174.nxs.h5"],
             "proposal": "IPTS-36301",

--- a/src/webmon_app/reporting/tests/test_report/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_report/test_view_util.py
@@ -406,6 +406,180 @@ class ViewUtilTest(TestCase):
         self.assertTrue("test_instrument/experiment/test_exp1" in rst[0]["experiment"])
         self.assertTrue("test_instrument/7" in rst[0]["run"])
 
+    @mock.patch("reporting.report.view_util.send_processing_request")
+    def test_processing_request_runtime_error_shows_user_friendly_message(self, mock_send_request):
+        """
+        Test that RuntimeError (catalog not found) shows a user-friendly message
+        instead of a 500 error. This fixes the bug where runs without Nexus files
+        showed internal server errors.
+        """
+        from django.contrib.messages import get_messages
+        from django.test import RequestFactory
+
+        from reporting.report.view_util import processing_request
+
+        # Setup: Make send_processing_request raise RuntimeError (catalog not found)
+        mock_send_request.side_effect = RuntimeError("Run 62174 not found in catalog")
+
+        # Create a request object with session and messages support
+        factory = RequestFactory()
+        request = factory.get("/report/pg3/62174/postprocess/")
+        request.user = mock.MagicMock()
+        request.user.username = "test_user"
+        request.user.is_staff = True
+
+        # Add session and messages middleware components
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.contrib.sessions.backends.db import SessionStore
+
+        setattr(request, "session", SessionStore())
+        setattr(request, "_messages", FallbackStorage(request))
+
+        # Execute: Call processing_request which should catch RuntimeError
+        response = processing_request(request, instrument="test_instrument", run_id=1, destination=None)
+
+        # Verify: Should redirect (not 500 error)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.endswith("/report/test_instrument/1/"))
+
+        # Verify: Should have user-friendly error message
+        messages = list(get_messages(request))
+        self.assertEqual(len(messages), 1)
+        self.assertIn("cannot be submitted for post-processing yet", str(messages[0]))
+        self.assertIn("NeXus data file is not available", str(messages[0]))
+
+    @mock.patch("reporting.report.view_util.send_processing_request")
+    def test_processing_request_generic_error_shows_generic_message(self, mock_send_request):
+        """
+        Test that generic exceptions (not RuntimeError) still show an error message
+        and redirect properly instead of crashing.
+        """
+        from django.contrib.messages import get_messages
+        from django.test import RequestFactory
+
+        from reporting.report.view_util import processing_request
+
+        # Setup: Make send_processing_request raise a generic exception
+        mock_send_request.side_effect = Exception("Network timeout")
+
+        # Create a request object with session and messages support
+        factory = RequestFactory()
+        request = factory.get("/report/hb2b/5757/reduce/")
+        request.user = mock.MagicMock()
+        request.user.username = "test_user"
+        request.user.is_staff = True
+
+        # Add session and messages middleware components
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.contrib.sessions.backends.db import SessionStore
+
+        setattr(request, "session", SessionStore())
+        setattr(request, "_messages", FallbackStorage(request))
+
+        # Execute: Call processing_request with generic exception
+        response = processing_request(request, instrument="test_instrument", run_id=1, destination=None)
+
+        # Verify: Should redirect (not 500 error)
+        self.assertEqual(response.status_code, 302)
+
+        # Verify: Should have generic error message
+        messages = list(get_messages(request))
+        self.assertEqual(len(messages), 1)
+        self.assertIn("unexpected error occurred", str(messages[0]))
+        self.assertIn("contact support", str(messages[0]))
+
+    @mock.patch("reporting.report.view_util.send_processing_request")
+    def test_processing_request_success_no_error_message(self, mock_send_request):
+        """
+        Test that successful post-processing requests don't show error messages.
+        """
+        from django.contrib.messages import get_messages
+        from django.test import RequestFactory
+
+        from reporting.report.view_util import processing_request
+
+        # Setup: send_processing_request succeeds without error
+        mock_send_request.return_value = None
+
+        # Create a request object
+        factory = RequestFactory()
+        request = factory.get("/report/pg3/62174/postprocess/")
+        request.user = mock.MagicMock()
+        request.user.username = "test_user"
+        request.user.is_staff = True
+
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.contrib.sessions.backends.db import SessionStore
+
+        setattr(request, "session", SessionStore())
+        setattr(request, "_messages", FallbackStorage(request))
+
+        # Execute
+        response = processing_request(request, instrument="test_instrument", run_id=1, destination=None)
+
+        # Verify: Should redirect successfully
+        self.assertEqual(response.status_code, 302)
+
+        # Verify: Should have NO error messages
+        messages = list(get_messages(request))
+        self.assertEqual(len(messages), 0)
+
+    @mock.patch("reporting.reporting_app.view_util.send_activemq_message")
+    @mock.patch("reporting.report.catalog.get_run_info")
+    def test_send_processing_request_import_fix(self, mock_get_run_info, mock_msg_sender):
+        """
+        Test that the import statement is now correct and doesn't raise ModuleNotFoundError.
+        This was the original bug: `from report.catalog import get_run_info` instead of
+        `from reporting.report.catalog import get_run_info`.
+        """
+        from reporting.report.view_util import send_processing_request
+
+        # Setup: Mock catalog to return empty data files (to trigger the import)
+        mock_get_run_info.return_value = {
+            "data_files": ["/SNS/PG3/IPTS-36301/nexus/PG3_62174.nxs.h5"],
+            "proposal": "IPTS-36301",
+        }
+        mock_msg_sender.return_value = None
+
+        inst = Instrument.objects.get(name="test_instrument")
+        run_id = DataRun.objects.get(run_number=1, instrument_id=inst)
+        # Clear the file path to force catalog lookup
+        run_id.file = ""
+        run_id.save()
+
+        # Execute: This should NOT raise ModuleNotFoundError anymore
+        try:
+            send_processing_request(inst, run_id)
+            import_worked = True
+        except ModuleNotFoundError:
+            import_worked = False
+
+        # Verify: Import should work correctly now
+        self.assertTrue(import_worked, "Import statement should be fixed to use 'from reporting.report.catalog'")
+
+    @mock.patch("reporting.reporting_app.view_util.send_activemq_message")
+    @mock.patch("reporting.report.catalog.get_run_info")
+    def test_send_processing_request_raises_runtime_error_when_no_catalog(self, mock_get_run_info, mock_msg_sender):
+        """
+        Test that send_processing_request raises RuntimeError when catalog info is missing.
+        """
+        from reporting.report.view_util import send_processing_request
+
+        # Setup: Mock catalog to return no data files
+        mock_get_run_info.return_value = {"data_files": [], "proposal": ""}
+        mock_msg_sender.return_value = None
+
+        inst = Instrument.objects.get(name="test_instrument")
+        run_id = DataRun.objects.get(run_number=1, instrument_id=inst)
+        run_id.file = ""  # Clear file to trigger catalog lookup
+        run_id.save()
+
+        # Execute & Verify: Should raise RuntimeError
+        with self.assertRaises(RuntimeError) as context:
+            send_processing_request(inst, run_id)
+
+        self.assertIn("not found in catalog", str(context.exception))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
# Description of the changes

This PR fixes a bug where users encountered HTTP 500 Internal Server Error when attempting to submit post-processing jobs for runs that haven't been translated to NeXus format yet. Instead of a cryptic server error, users now see a helpful message explaining that the run isn't ready and suggesting they contact the data acquisition team if the issue persists.

**Root causes fixed:**
- Incorrect import statement (`from report.catalog` → `from reporting.report.catalog`) that caused `ModuleNotFoundError`
- Bare exception handler that returned generic 500 errors instead of user-friendly messages

**Changes made:**
- Fixed the import statement in `view_util.py`
- Added Django messages framework to display context-specific error messages
- Improved exception handling to distinguish between missing catalog entries (user-fixable) and system errors
- Updated base template to display Django messages alongside existing alert pattern
- Added 6 comprehensive unit tests covering all error scenarios

**User impact:**
When a run's NeXus file isn't available in the catalog (e.g., translation failures like the March 8 incident), users now see:
> "This run cannot be submitted for post-processing yet. The NeXus data file is not available in the catalog. Please wait for the run to be translated to NeXus format or contact the data acquisition team if this error persists."

Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM 15405](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=15405)
- Links to related issues or pull requests: N/A

# :warning: Manual test for the reviewer

**Test scenario 1: Run without NeXus file (catalog entry missing)**
1. Find or create a run in the database that has an empty `file` field and no catalog entry
2. Log in as an instrument staff user
3. Navigate to the run detail page
4. Click "Submit for post-processing" or "Submit for reduction"
5. **Expected:** Should redirect back to run page with user-friendly error message about NeXus file not being available
6. **Not expected:** Should NOT show HTTP 500 error

**Test scenario 2: Normal run with NeXus file**
1. Navigate to a run with a valid NeXus file
2. Click "Submit for post-processing"
3. **Expected:** Should show confirmation dialog as normal, no error messages

**Test scenario 3: Run unit tests**
```bash
cd /home/dzj/data_workflow
DJANGO_SETTINGS_MODULE=reporting.reporting_app.settings.unittest pixi run -e test pytest src/webmon_app/reporting/tests/test_report/test_view_util.py -k "processing_request" -v
```
All 7 tests should pass.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent