### PR TITLE
Update WebMon footer to comply with ORNL website standards

### DIFF
--- a/src/webmon_app/reporting/static/reporting_layout.css
+++ b/src/webmon_app/reporting/static/reporting_layout.css
@@ -397,6 +397,13 @@ img {border: 0;}
     width: 60%;
 }
 
+.ornlFooter .attribution
+{
+    margin: 0px 0px 8px 0px;
+    line-height: 1.5;
+    color: #333;
+}
+
 .ornlFooter .links ul
 {
     list-style: none;

--- a/src/webmon_app/reporting/templates/base.html
+++ b/src/webmon_app/reporting/templates/base.html
@@ -118,18 +118,18 @@
     <table style="width: 100%">
       <tr>
         <td>
-          <a id="FooterUTBLogoLink" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
+          <a id="FooterUTBLogoLink" title="UT-Battelle" href="https://www.ut-battelle.org/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
         </td>
         <td class="links">
           <p class="attribution">SNS and HFIR are DOE Office of Science User Facilities operated by Oak Ridge National Laboratory.<br>
           Oak Ridge National Laboratory is managed by UT-Battelle for the U.S. Department of Energy.</p>
           <ul>
             <li><a id="HyperLink2" title="Security Notice" href="https://www.ornl.gov/content/security-privacy-notice" target="_blank" rel="noopener noreferrer">Security Notice</a><span>·</span></li>
-            <li><a id="HyperLink6" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" rel="noopener noreferrer">UT-Battelle</a></li>
+            <li><a id="HyperLink6" title="UT-Battelle" href="https://www.ut-battelle.org/" target="_blank" rel="noopener noreferrer">UT-Battelle</a></li>
           </ul>
         </td>
         <td>
-          <a id="FooterScienceLogoLink" title="Department of Energy, Office of Science" href="https://science.osti.gov/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy, Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy, Office of Science" /></a>
+          <a id="FooterScienceLogoLink" title="Department of Energy, Office of Science" href="https://science.energy.gov/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy, Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy, Office of Science" /></a>
         </td>
       </tr>
     </table>

--- a/src/webmon_app/reporting/templates/base.html
+++ b/src/webmon_app/reporting/templates/base.html
@@ -76,7 +76,7 @@
   {% if gravatar_url %}<img src="{{ gravatar_url|safe }}&s=16" height="16" width="16" alt="{{ user.username }}">{% endif %} {% if profile_url %}<a href="{{ profile_url }}">{{ user.username }}</a> {% else %}{{ user.username }}{% endif %} |{% if user.is_staff %} <a href="{% url 'report:processing_admin' %}"><b>admin</b></a> |{% endif %}{% if user.is_authenticated %} <a href="{{ logout_url }}">logout</a>{% else %} <a href="{{ login_url }}">login</a>{% endif %}
 </div>
 
-<a class="banner_logo" href="http://neutrons.ornl.gov/" target="_blank"><img title="SNS" src="/static/ornl_hfir_sns.png" alt="SNS" /></a>
+<a class="banner_logo" href="https://neutrons.ornl.gov/" target="_blank"><img title="SNS" src="/static/ornl_hfir_sns.png" alt="SNS" /></a>
 <div class="banner_title">{% block banner %}Data Processing Report{% endblock %}</div>
 
 <div class='user_alert'>
@@ -118,18 +118,18 @@
     <table style="width: 100%">
       <tr>
         <td>
-          <a id="FooterUTBLogoLink" title="UT-Battelle" href="http://ut-battelle.org" target="_blank" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
+          <a id="FooterUTBLogoLink" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
         </td>
         <td class="links">
+          <p class="attribution">SNS and HFIR are DOE Office of Science User Facilities operated by Oak Ridge National Laboratory.<br>
+          Oak Ridge National Laboratory is managed by UT-Battelle for the U.S. Department of Energy.</p>
           <ul>
-            <li><a id="HyperLink2" title="Security Notice" href="http://www.ornl.gov/ornlhome/disclaimers.shtml" target="_blank">Security Notice</a><span>·</span></li>
-            <li><a id="HyperLink3" title="Internal Users" href="http://www.ornl.gov/ornlhome/remote.shtml" target="_blank">Internal Users</a><br></li>
-            <li><a id="HyperLink5" title="DOE - Oak Ridge" href="http://www.oakridge.doe.gov/external/" target="_blank">DOE - Oak Ridge</a><span>·</span></li>
-            <li><a id="HyperLink6" title="UT-Battelle" href="http://ut-battelle.org" target="_blank">UT-Battelle</a></li>
+            <li><a id="HyperLink2" title="Security Notice" href="https://www.ornl.gov/content/security-privacy-notice" target="_blank">Security Notice</a><span>·</span></li>
+            <li><a id="HyperLink6" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank">UT-Battelle</a></li>
           </ul>
         </td>
         <td>
-          <a id="FooterScienceLogoLink" title="Department of Energy , Office of Science" href="http://science.energy.gov/" target="_blank" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy , Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy , Office of Science" /></a>
+          <a id="FooterScienceLogoLink" title="Department of Energy, Office of Science" href="https://science.osti.gov/" target="_blank" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy, Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy, Office of Science" /></a>
         </td>
       </tr>
     </table>

--- a/src/webmon_app/reporting/templates/base.html
+++ b/src/webmon_app/reporting/templates/base.html
@@ -76,7 +76,7 @@
   {% if gravatar_url %}<img src="{{ gravatar_url|safe }}&s=16" height="16" width="16" alt="{{ user.username }}">{% endif %} {% if profile_url %}<a href="{{ profile_url }}">{{ user.username }}</a> {% else %}{{ user.username }}{% endif %} |{% if user.is_staff %} <a href="{% url 'report:processing_admin' %}"><b>admin</b></a> |{% endif %}{% if user.is_authenticated %} <a href="{{ logout_url }}">logout</a>{% else %} <a href="{{ login_url }}">login</a>{% endif %}
 </div>
 
-<a class="banner_logo" href="https://neutrons.ornl.gov/" target="_blank"><img title="SNS" src="/static/ornl_hfir_sns.png" alt="SNS" /></a>
+<a class="banner_logo" href="https://neutrons.ornl.gov/" target="_blank" rel="noopener noreferrer"><img title="SNS" src="/static/ornl_hfir_sns.png" alt="SNS" /></a>
 <div class="banner_title">{% block banner %}Data Processing Report{% endblock %}</div>
 
 <div class='user_alert'>
@@ -118,18 +118,18 @@
     <table style="width: 100%">
       <tr>
         <td>
-          <a id="FooterUTBLogoLink" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
+          <a id="FooterUTBLogoLink" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:44px;width:150px;"><img title="UT-Battelle" src="/static/utb_logo.png" alt="UT-Battelle" /></a>
         </td>
         <td class="links">
           <p class="attribution">SNS and HFIR are DOE Office of Science User Facilities operated by Oak Ridge National Laboratory.<br>
           Oak Ridge National Laboratory is managed by UT-Battelle for the U.S. Department of Energy.</p>
           <ul>
-            <li><a id="HyperLink2" title="Security Notice" href="https://www.ornl.gov/content/security-privacy-notice" target="_blank">Security Notice</a><span>·</span></li>
-            <li><a id="HyperLink6" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank">UT-Battelle</a></li>
+            <li><a id="HyperLink2" title="Security Notice" href="https://www.ornl.gov/content/security-privacy-notice" target="_blank" rel="noopener noreferrer">Security Notice</a><span>·</span></li>
+            <li><a id="HyperLink6" title="UT-Battelle" href="https://www.utbattelle.org/" target="_blank" rel="noopener noreferrer">UT-Battelle</a></li>
           </ul>
         </td>
         <td>
-          <a id="FooterScienceLogoLink" title="Department of Energy, Office of Science" href="https://science.osti.gov/" target="_blank" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy, Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy, Office of Science" /></a>
+          <a id="FooterScienceLogoLink" title="Department of Energy, Office of Science" href="https://science.osti.gov/" target="_blank" rel="noopener noreferrer" style="display:inline-block;height:56px;width:173px;"><img title="Department of Energy, Office of Science" src="/static/doe_os_logo.png" alt="Department of Energy, Office of Science" /></a>
         </td>
       </tr>
     </table>

--- a/tests/test_DASMONPageView.py
+++ b/tests/test_DASMONPageView.py
@@ -36,7 +36,7 @@ class TestDASMONPageView:
         tree = etree.parse(StringIO(dasmon_diagnostics.text), parser)
         table_content = tree.xpath("//tr/td//text()")
         # verify number of entries in the tables
-        expected_number_of_entries = 54  # Updated for current CI environment
+        expected_number_of_entries = 52  # Updated for current CI environment
         assert len(table_content) == expected_number_of_entries
         # -- DASMON diagnostics
         status = table_content[1]


### PR DESCRIPTION
# Description of the changes

Brings the WebMon footer in line with the ORNL SBMS "Brand External Websites" procedure and general website standards. The main addition is the required attribution statement explaining ORNL's affiliation with DOE and UT-Battelle. Several footer links that have been broken for some time are also cleaned up — a dead domain, two paths that no longer exist on ornl.gov, and an outdated internal users page. All remaining links have been updated from http to https.

Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM 16929](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16929)
- Links to related issues or pull requests:

# :warning: Manual test for the reviewer

Load any WebMon page and check the footer:
1. Confirm the attribution statement is visible: *"SNS and HFIR are DOE Office of Science User Facilities operated by Oak Ridge National Laboratory. Oak Ridge National Laboratory is managed by UT-Battelle for the U.S. Department of Energy."*
2. Click **Security Notice** — should land on `https://www.ornl.gov/content/security-privacy-notice` (not a 404)
3. Click the **UT-Battelle** text link and logo — should open `https://www.utbattelle.org/`
4. Click the **DOE Office of Science** logo — should open `https://science.osti.gov/`
5. Click the **SNS/HFIR banner logo** at the top — should open `https://neutrons.ornl.gov/`

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent