### PR TITLE
Restrict run title visibility and require login for instrument pages

### DIFF
--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -4,6 +4,7 @@ Live monitoring
 """
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -141,14 +142,14 @@ def run_summary_update(request):
     instrument_search = request.GET.get("columns[0][search][value]", "")
     run_search = request.GET.get("columns[1][search][value]", "")
     date_search = request.GET.get("columns[2][search][value]", "")
-    title_search = request.GET.get("columns[3][search][value]", "")
-    status_search = request.GET.get("columns[4][search][value]", "")
+    status_search = request.GET.get("columns[3][search][value]", "")
 
     run_list, count, filtered_count = view_util.get_run_list_newest(
-        offset, limit, instrument_search, run_search, date_search, status_search, title_search=title_search
+        offset, limit, instrument_search, run_search, date_search, status_search
     )
     data = {}
-    data["data"] = report_view_util.get_run_list_dict(run_list)
+    # Run titles are not shown on the cross-instrument summary page
+    data["data"] = report_view_util.get_run_list_dict(run_list, show_run_title=False)
     data["recordsTotal"] = count
     data["recordsFiltered"] = filtered_count
     data["draw"] = draw
@@ -156,7 +157,7 @@ def run_summary_update(request):
     return JsonResponse(data)
 
 
-@users_view_util.login_or_local_required
+@login_required
 @cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
 @cache_control(private=True)
 @users_view_util.monitor
@@ -188,7 +189,7 @@ def live_monitor(request, instrument):
     return render(request, "dasmon/live_monitor.html", template_values)
 
 
-@users_view_util.login_or_local_required
+@login_required
 @cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
 @cache_control(private=True)
 @users_view_util.monitor
@@ -338,7 +339,7 @@ def get_update(request, instrument):
     run_list, count, filtered_count = view_util.get_run_list_instrument_newest(
         instrument_id, offset, limit, run_search, date_search, status_search, title_search=title_search
     )
-    data_dict["data"] = report_view_util.get_run_list_dict(run_list)
+    data_dict["data"] = report_view_util.get_run_list_dict(run_list, request=request)
     data_dict["recordsTotal"] = count
     data_dict["recordsFiltered"] = filtered_count
     data_dict["draw"] = draw

--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -306,6 +306,7 @@ def diagnostics(request, instrument):
 @users_view_util.login_or_local_required_401
 @cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
 @cache_control(private=True)
+@vary_on_cookie
 def get_update(request, instrument):
     limit = int(request.GET.get("length", 10))
     offset = int(request.GET.get("start", 0))

--- a/src/webmon_app/reporting/pvmon/views.py
+++ b/src/webmon_app/reporting/pvmon/views.py
@@ -5,6 +5,7 @@ Live PV monitoring
 import json
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -20,7 +21,7 @@ from reporting.report.models import Instrument
 from . import view_util
 
 
-@users_view_util.login_or_local_required
+@login_required
 @cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
 @cache_control(private=True)
 @users_view_util.monitor

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -24,6 +24,7 @@ from django.utils.html import escape
 
 import reporting.dasmon.view_util as dasmon_view_util
 import reporting.reporting_app.view_util as reporting_view_util
+import reporting.users.view_util as users_view_util
 from reporting.report.models import (
     IPTS,
     DataRun,
@@ -491,12 +492,15 @@ def get_run_status_text_dict(run_list, use_element_id=False):
     return run_statuses
 
 
-def get_run_list_dict(run_list):
+def get_run_list_dict(run_list, request=None, show_run_title=True):
     """
     Get a list of run object and transform it into a list of
     dictionaries that can be used to fill a table.
 
     :param run_list: list of run object (usually a QuerySet)
+    :param request: HTTP request, used to gate the run title by experiment
+                    access. When None, the title is shown (legacy behavior).
+    :param show_run_title: set False to never include the run title
     """
     run_dicts = []
 
@@ -517,9 +521,14 @@ def get_run_list_dict(run_list):
             reduce_url = reverse("report:submit_for_reduction", args=[str(r.instrument_id), r.run_number])
             instr_url = reverse("dasmon:live_runs", args=[str(r.instrument_id)])
 
-            # Format run_title with truncation and tooltip
+            # Format run_title with truncation and tooltip. Titles can carry
+            # proprietary experiment info, so only expose them to users with
+            # access to the experiment (see users_view_util.is_experiment_member).
             run_title_display = ""
-            if r.run_title:
+            title_allowed = show_run_title and (
+                request is None or users_view_util.is_experiment_member(request, r.instrument_id, r.ipts_id)
+            )
+            if r.run_title and title_allowed:
                 # Use the same pruning function used in DASMON views
                 pruned_title = dasmon_view_util._prune_title_string(r.run_title)
                 # Truncate long titles for display with escaped HTML

--- a/src/webmon_app/reporting/report/view_util.py
+++ b/src/webmon_app/reporting/report/view_util.py
@@ -510,6 +510,25 @@ def get_run_list_dict(run_list, request=None, show_run_title=True):
 
     run_status_text_dict = get_run_status_text_dict(run_list, use_element_id=True)
 
+    # Cache experiment-membership decisions per experiment so is_experiment_member
+    # (which may hit LDAP and the database) is evaluated at most once per
+    # experiment, even for large pages.
+    title_access_cache = {}
+
+    def title_allowed(run):
+        # Titles can carry proprietary experiment info, so only expose them to
+        # users with access to the experiment (see is_experiment_member).
+        if not show_run_title:
+            return False
+        if request is None:
+            return True
+        cache_key = (run.instrument_id_id, run.ipts_id_id)
+        if cache_key not in title_access_cache:
+            title_access_cache[cache_key] = users_view_util.is_experiment_member(
+                request, run.instrument_id, run.ipts_id
+            )
+        return title_access_cache[cache_key]
+
     try:
         for r in run_list:
             if r.id not in run_status_text_dict:
@@ -521,14 +540,9 @@ def get_run_list_dict(run_list, request=None, show_run_title=True):
             reduce_url = reverse("report:submit_for_reduction", args=[str(r.instrument_id), r.run_number])
             instr_url = reverse("dasmon:live_runs", args=[str(r.instrument_id)])
 
-            # Format run_title with truncation and tooltip. Titles can carry
-            # proprietary experiment info, so only expose them to users with
-            # access to the experiment (see users_view_util.is_experiment_member).
+            # Format run_title with truncation and tooltip
             run_title_display = ""
-            title_allowed = show_run_title and (
-                request is None or users_view_util.is_experiment_member(request, r.instrument_id, r.ipts_id)
-            )
-            if r.run_title and title_allowed:
+            if r.run_title and title_allowed(r):
                 # Use the same pruning function used in DASMON views
                 pruned_title = dasmon_view_util._prune_title_string(r.run_title)
                 # Truncate long titles for display with escaped HTML

--- a/src/webmon_app/reporting/report/views.py
+++ b/src/webmon_app/reporting/report/views.py
@@ -417,6 +417,7 @@ def live_errors(request, instrument):
 
 @users_view_util.login_or_local_required_401
 @cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
+@vary_on_cookie
 def get_experiment_update(request, instrument, ipts):
     """
     Ajax call to get updates behind the scenes
@@ -465,7 +466,7 @@ def get_experiment_update(request, instrument, ipts):
         status_search,
         title_search=title_search,
     )
-    data["data"] = view_util.get_run_list_dict(run_list)
+    data["data"] = view_util.get_run_list_dict(run_list, request=request)
     data["recordsTotal"] = count
     data["recordsFiltered"] = filtered_count
     data["draw"] = draw

--- a/src/webmon_app/reporting/templates/dasmon/run_summary.html
+++ b/src/webmon_app/reporting/templates/dasmon/run_summary.html
@@ -25,34 +25,29 @@
         { data: 'instrument_id' },
         { data: 'run' },
         { data: 'timestamp' },
-        { data: 'run_title' },
         { data: 'status' },
         { data: 'oncat_link' }
       ],
       columnDefs: [
         {
           "targets": 0,
-          "width": "8%"
+          "width": "10%"
         },
         {
           "targets": 1,
-          "width": "8%"
+          "width": "10%"
         },
         {
           "targets": 2,
-          "width": "15%"
+          "width": "20%"
         },
         {
           "targets": 3,
-          "width": "40%"
+          "width": "15%"
         },
         {
           "targets": 4,
-          "width": "12%"
-        },
-        {
-          "targets": 5,
-          "width": "8%"
+          "width": "10%"
         }
       ],
       lengthMenu: [25, 50, 100, 500, 1000],
@@ -92,7 +87,6 @@ List of latest runs:<br><br>
         <th>Instr.</th>
         <th>Run</th>
         <th>Created on</th>
-        <th>Run Title</th>
         <th>Status</th>
         <th>ONCat</th>
       </tr>
@@ -101,7 +95,6 @@ List of latest runs:<br><br>
     </tbody>
     <tfoot>
       <tr>
-        <th></th>
         <th></th>
         <th></th>
         <th></th>

--- a/src/webmon_app/reporting/tests/test_report/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_report/test_view_util.py
@@ -316,6 +316,32 @@ class ViewUtilTest(TestCase):
         # Cleanup
         run.delete()
 
+    def test_get_run_list_dict_hides_run_title(self):
+        """run_title is blanked when show_run_title is False or the user is not an experiment member"""
+        from django.contrib.auth.models import User
+        from django.test import RequestFactory
+
+        from reporting.report.view_util import get_run_list_dict
+
+        inst = Instrument.objects.get(name="test_instrument")
+        ipts = IPTS.objects.get(expt_name="test_exp1")
+        run = DataRun.objects.create(
+            run_number=996, ipts_id=ipts, instrument_id=inst, file="tmp/test_996.nxs", run_title="Secret Title"
+        )
+        run.save()
+        runs = DataRun.objects.filter(run_number=996, instrument_id=inst)
+
+        # Summary page: title never shown
+        self.assertEqual(get_run_list_dict(runs, show_run_title=False)[0]["run_title"], "")
+
+        # Non-member user: title hidden
+        request = RequestFactory().get("/")
+        request.user = User.objects.create_user(username="not_a_member")
+        self.assertEqual(get_run_list_dict(runs, request=request)[0]["run_title"], "")
+
+        # Cleanup
+        run.delete()
+
     def test_get_run_status_text_dict(self):
         from reporting.report.view_util import get_run_status_text_dict
 

--- a/tests/test_RunPageView.py
+++ b/tests/test_RunPageView.py
@@ -300,11 +300,12 @@ class TestRunPageView:
 
     def verifyLatestRun(self, r):
         self.assertHtml("""<div class="summary">List of latest runs:<br><br>""", r.text)
+        # The Run Title column was removed from the summary page so that run
+        # titles are not exposed on the cross-instrument latest-runs table.
         self.assertHtml(
             """<th>Instr.</th>
             <th>Run</th>
             <th>Created on</th>
-            <th>Run Title</th>
             <th>Status</th>
             <th>ONCat</th>""",
             r.text,


### PR DESCRIPTION
# Description of the changes

Based on feedback from Andrei, run titles can contain proprietary experiment
information and should not be exposed to users who aren't part of the
experiment. This PR tightens access in three places:

- **Latest runs summary (`/dasmon/summary/`)** — removes the Run Title column
  entirely. The title is also dropped from the AJAX payload, so it isn't just
  hidden in the DOM but never leaves the server.
- **Instrument pages (`/dasmon/<instrument>/`, `/dasmon/<instrument>/runs/`,
  `/pvmon/<instrument>/`)** — now require an authenticated login. Previously the
  `login_or_local_required` decorator let anyone on the SNS domain view these
  without logging in, which is why titles were effectively public.
- **Run title on instrument pages** — visibility is now gated per-run by
  experiment membership through `is_experiment_member`. This reuses the exact
  check that already protects the run detail page, so a title is shown to
  exactly the users who could already open that run's detail: experiment
  members, instrument scientists/team, IHC, and super users. General logged-in
  users see blank titles for experiments they aren't part of.

`get_run_list_dict` gained optional `request` and `show_run_title` parameters;
existing callers that pass neither keep their previous behavior.

Check all that apply:
- [ ] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: [EWM 16936](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=16963)
- Links to related issues or pull requests: N/A

# :warning: Manual test for the reviewer

1. **Summary page** — As a non-logged-in user, visit `/dasmon/summary/` and
   confirm the **Run Title** column is gone and the table still renders/sorts
   correctly.
2. **Instrument pages** — While logged out, visit `/dasmon/<instrument>/`,
   `/dasmon/<instrument>/runs/`, and `/pvmon/<instrument>/`. Confirm each
   redirects to the login page instead of showing the page.
3. **Title gating (non-member)** — Log in as a general user who is *not* a
   member of a given experiment and open `/dasmon/<instrument>/runs/`. Confirm
   run titles for experiments you don't belong to are blank, while titles for
   your own experiments show.
4. **Title gating (privileged)** — Log in as an instrument scientist / experiment
   member and confirm run titles are visible as expected.

> Note: title gating depends on experiment membership being present in the
> user's LDAP groups (the standard IPTS group model). Worth confirming that
> proposal-provisioned accounts resolve through LDAP; if not, legitimate members
> would see blank titles (fail-closed — never an over-exposure).

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent