### PR TITLE
Bump post-processing agent to v4.5.0

### DIFF
--- a/Dockerfile.autoreducer
+++ b/Dockerfile.autoreducer
@@ -30,7 +30,7 @@ COPY tests/python3-pyoncat-2.1-1.noarch.rpm /tmp/
 RUN dnf install -y /tmp/python3-pyoncat-2.1-1.noarch.rpm
 
 # install postprocessing
-RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v4.1.0/postprocessing-4.1.0-1.el9.noarch.rpm
+RUN dnf install -y https://github.com/neutrons/post_processing_agent/releases/download/v4.5.0/postprocessing-4.5.0-1.el9.noarch.rpm
 
 # Install dependencies
 ARG PLOTLY_VERSION=5


### PR DESCRIPTION
# Description of the changes
Picks up the VENUS image cataloging run number filter (post_processing_agent#110, v4.5.0). Previous pin was v4.1.0.

Check all that apply:
- [ ] updated documentation
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:
N/A
# :warning: Manual test for the reviewer
(Instructions for testing here)

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent
