### PR TITLE
Restore the monitored PV table on the instrument status page

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -47,7 +47,7 @@ Monitored Variables
 
 URL: https://monitor.sns.gov/database/pvmon/monitoredvariable/
 
-The ``Monitored Variable`` model control which PVs appear in the
+The ``Monitored Variable`` model controls which PVs appear in the
 monitored PV table at the top of the instrument status page. To promote
 a PV from the PV page to the status page just create a model with the
 correct ``Instrument`` and ``PV Name``. To remove a PV from the status

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -47,10 +47,18 @@ Monitored Variables
 
 URL: https://monitor.sns.gov/database/pvmon/monitoredvariable/
 
-The ``Monitored Variable`` model control which PVs appear on the
-instrument status page. To promote a PV from the PV page to the status
-page just create a model with the correct ``Instrument`` and ``PV
-Name``. To remove a PV from the status page just delete that model.
+The ``Monitored Variable`` model control which PVs appear in the
+monitored PV table at the top of the instrument status page. To promote
+a PV from the PV page to the status page just create a model with the
+correct ``Instrument`` and ``PV Name``. To remove a PV from the status
+page just delete that model.
+
+Note that this model is normally maintained by DASMON rather than by
+hand: the beamline sets the list of monitored PVs through the
+``MonitorPVs`` IOC, and DASMON pushes that list to the database by
+calling the ``setInstrumentPVs`` stored procedure, which replaces the
+entries for that instrument. Manual edits are therefore overwritten the
+next time the beamline updates its list.
 
 For example, the following ``Monitored Variables`` exist for TOPAZ,
 

--- a/src/webmon_app/reporting/dasmon/urls.py
+++ b/src/webmon_app/reporting/dasmon/urls.py
@@ -22,4 +22,9 @@ urlpatterns = [
     re_path(r"^(?P<instrument>[\w]+)/runs/$", views.live_runs, name="live_runs"),
     re_path(r"^(?P<instrument>[\w]+)/update/$", views.get_update, name="get_update"),
     re_path(r"^(?P<instrument>[\w]+)/diagnostics/$", views.diagnostics, name="diagnostics"),
+    re_path(
+        r"^(?P<instrument>[\w]+)/monitored_pvs/$",
+        views.get_monitored_pv_table,
+        name="get_monitored_pv_table",
+    ),
 ]

--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -964,10 +964,10 @@ def get_monitored_pvs(instrument_id):
 
         try:
             latest_values = PVCache.objects.filter(instrument=instrument_id, name=item.pv_name)
-            if len(latest_values) == 0:
+            if not latest_values.exists():
                 latest_values = PVStringCache.objects.filter(instrument=instrument_id, name=item.pv_name)
             latest = latest_values.latest("timestamp")
-            if isinstance(latest.value, float):
+            if isinstance(latest.value, (int, float)):
                 value = "%g" % latest.value
             else:
                 value = "%s" % latest.value

--- a/src/webmon_app/reporting/dasmon/view_util.py
+++ b/src/webmon_app/reporting/dasmon/view_util.py
@@ -15,6 +15,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import formats, timezone
 
+import reporting.pvmon.view_util as pvmon_view_util
 import reporting.report.view_util as report_view_util
 import reporting.users.view_util as users_view_util
 from reporting.dasmon.models import (
@@ -23,7 +24,7 @@ from reporting.dasmon.models import (
     StatusCache,
     StatusVariable,
 )
-from reporting.pvmon.models import PVCache
+from reporting.pvmon.models import MonitoredVariable, PVCache, PVStringCache
 from reporting.report.models import DataRun, Information, Instrument
 
 LOGNAME = "dasmon:view_util"
@@ -234,6 +235,7 @@ def fill_template_values(request, **template_args):
     template_args["live_monitor_url"] = reverse("dasmon:live_monitor", args=[instr])
     template_args["live_runs_url"] = reverse("dasmon:live_runs", args=[instr])
     template_args["live_pv_url"] = reverse("pvmon:pv_monitor", args=[instr])
+    template_args["monitored_pvs_url"] = reverse("dasmon:get_monitored_pv_table", args=[instr])
 
     # template_args["help_url"] = reverse('dasmon:user_help')
 
@@ -930,6 +932,75 @@ def get_run_list_newest(offset, limit, instrument_search, run_search, date_searc
 
     run_list = run_list[offset : limit + offset]  # noqa E203
     return run_list, count, filtered_count
+
+
+def get_monitored_pvs(instrument_id):
+    """
+    Get the monitored PVs for a given instrument, with their latest value and history.
+
+    The list of monitored PVs is chosen at the beamline and pushed to WebMon by DASMON,
+    which calls the ``setInstrumentPVs`` stored procedure to populate the
+    ``MonitoredVariable`` table. The PV values themselves are written by DASMON
+    straight into the PV cache tables.
+
+    :param instrument_id: Instrument object
+    :return: list of dicts with the keys ``key``, ``value``, ``data`` and ``timestamp``,
+             sorted by PV name
+    """
+    logger = logging.getLogger(LOGNAME)
+    monitored_pvs = []
+
+    try:
+        monitored = MonitoredVariable.objects.filter(instrument=instrument_id)
+    except:  # noqa: E722
+        logger.exception("Could not read the monitored PVs:")
+        return monitored_pvs
+
+    for item in monitored:
+        # setInstrumentPVs stores a placeholder entry with no PV attached when an
+        # instrument has an empty list of monitored PVs, so skip those.
+        if item.pv_name is None:
+            continue
+
+        try:
+            latest_values = PVCache.objects.filter(instrument=instrument_id, name=item.pv_name)
+            if len(latest_values) == 0:
+                latest_values = PVStringCache.objects.filter(instrument=instrument_id, name=item.pv_name)
+            latest = latest_values.latest("timestamp")
+            if isinstance(latest.value, float):
+                value = "%g" % latest.value
+            else:
+                value = "%s" % latest.value
+            timestamp = formats.localize(timezone.localtime(latest.timestamp))
+        except:  # noqa: E722
+            # The PV is monitored but no value has been received for it yet
+            value = "No data available"
+            timestamp = "-"
+
+        # History used to draw the inline sparkline next to the value
+        history = []
+        try:
+            data = pvmon_view_util.get_live_variables(request=None, instrument_id=instrument_id, key_id=item.pv_name)
+            if data is not None and len(data) > 0 and len(data[0]) > 1:
+                for point in data[0][1]:
+                    history.append("%g:%g" % (point[0], point[1]))
+        except:  # noqa: E722
+            logger.exception(f"Error processing data for {instrument_id} {item.pv_name}:")
+
+        monitored_pvs.append(
+            {
+                "key": str(item.pv_name),
+                "value": value,
+                "data": ",".join(history),
+                "timestamp": timestamp,
+            }
+        )
+
+    try:
+        return sorted(monitored_pvs, key=lambda pv: pv["key"].lower())
+    except:  # noqa: E722
+        logger.exception("Could not sort the monitored PV list:")
+    return monitored_pvs
 
 
 def get_instrument_status_summary(expert=False) -> list:

--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -5,8 +5,9 @@ Live monitoring
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.template import loader
 from django.urls import reverse
 from django.utils import formats, timezone
 from django.views.decorators.cache import cache_control, cache_page
@@ -187,6 +188,25 @@ def live_monitor(request, instrument):
     template_values = view_util.fill_template_values(request, **template_values)
 
     return render(request, "dasmon/live_monitor.html", template_values)
+
+
+@users_view_util.login_or_local_required_401
+@cache_page(settings.FAST_PAGE_CACHE_TIMEOUT)
+@cache_control(private=True)
+@vary_on_cookie
+def get_monitored_pv_table(request, instrument):
+    """
+    Ajax call to get the table of monitored PVs
+
+    :param instrument: instrument name
+    """
+    instrument_id = get_object_or_404(Instrument, name=instrument.lower())
+    template = loader.get_template("dasmon/monitored_pv_table.html")
+    template_values = {"monitored_pvs": view_util.get_monitored_pvs(instrument_id)}
+    response = HttpResponse(template.render(template_values), content_type="text/html")
+    response["Connection"] = "close"
+    response["Content-Length"] = len(response.content)
+    return response
 
 
 @login_required

--- a/src/webmon_app/reporting/dasmon/views.py
+++ b/src/webmon_app/reporting/dasmon/views.py
@@ -205,7 +205,6 @@ def get_monitored_pv_table(request, instrument):
     template_values = {"monitored_pvs": view_util.get_monitored_pvs(instrument_id)}
     response = HttpResponse(template.render(template_values), content_type="text/html")
     response["Connection"] = "close"
-    response["Content-Length"] = len(response.content)
     return response
 
 

--- a/src/webmon_app/reporting/templates/dasmon/live_monitor.html
+++ b/src/webmon_app/reporting/templates/dasmon/live_monitor.html
@@ -29,9 +29,11 @@
     //************************************************************************80
     function poll() {
         var query_str = "";
+        var pv_query_str = "";
         var options;
         for (var i=0; i<Plots.length; i++){
             if (Plots[i].option === "1") query_str += Plots[i].element_id + ",";
+            else if (Plots[i].option === "2") pv_query_str += Plots[i].element_id + ",";
         }
         $.ajax({ url: "{{ update_url }}?time="+plot_timeframe+"&vars="+query_str, success: function(data){
                 update_from_ajax_data(data);
@@ -64,11 +66,39 @@
             }
         });
 
+        if (pv_query_str.length>0) {
+            $.ajax({ url: "{{ pv_url }}?time="+plot_timeframe+"&vars="+pv_query_str, success: function(data) {
+                for (var i=0; i<data.live_plot_data.length; i++){
+                    for (var j=0; j<Plots.length; j++){
+                        if (data.live_plot_data[i][0] === Plots[j].element_id){
+                            Plots[j].plotted_data = data.live_plot_data[i][1];
+                            plot_1d(Plots[j].plotted_data, Plots[j].plot_id, Plots[j].plot_options)
+                            break;
+                        }
+                    }
+                }
+            }, dataType: "json", timeout: 2000, cache: true,
+            statusCode: { 401: function() {
+                        new_alert("Your session expired. Please log in again");
+                        show_alert();
+                    }
+                }
+            });
+        }
+        get_monitored_pvs();
+
     };
 
     $( document ).tooltip({
       items: '*:not(.ui-dialog-titlebar-close)'
     });
+
+    function get_monitored_pvs()
+    {
+        $.ajax({ url: "{{ monitored_pvs_url }}", success: function(data) {
+            $('#monitored_pv_table').replaceWith(data);
+        }, dataType: "html", timeout: 30000, cache: true });
+    }
 
 </script>
 {% endblock %}
@@ -83,6 +113,7 @@
 
 {% block bodytop %}
 <script id="source" language="javascript" type="text/javascript">
+    get_monitored_pvs();
     setInterval(poll, 5000);
 </script>
 {% endblock %}

--- a/src/webmon_app/reporting/templates/dasmon/monitored_pv_table.html
+++ b/src/webmon_app/reporting/templates/dasmon/monitored_pv_table.html
@@ -1,4 +1,4 @@
-<span id='monitored_pv_table'>
+<div id='monitored_pv_table'>
 {% if monitored_pvs %}
    <script id="source" language="javascript" type="text/javascript">
    $(function() { $('.inlinesparkline').sparkline('html',
@@ -29,4 +29,4 @@
       <br>
    </div>
 {% endif %}
-</span>
+</div>

--- a/src/webmon_app/reporting/templates/dasmon/monitored_pv_table.html
+++ b/src/webmon_app/reporting/templates/dasmon/monitored_pv_table.html
@@ -1,0 +1,32 @@
+<span id='monitored_pv_table'>
+{% if monitored_pvs %}
+   <script id="source" language="javascript" type="text/javascript">
+   $(function() { $('.inlinesparkline').sparkline('html',
+                                                  {type: 'line',width: '50px',
+                                                   spotColor: 'undefined',
+                                                   minSpotColor: 'undefined',
+                                                   maxSpotColor: 'undefined',
+                                                   highlightSpotColor: 'undefined'} ); });
+   </script>
+   <div class="box">
+      <table class="message_table fixed_table" id="monitored_pv_value_table">
+      <thead>
+      <tr>
+          <th> Monitored PV </th> <th> Value </th> <th style="width:50px;min-width:50px;"> History </th> <th style="width:170px;min-width:170px;"> Last Updated </th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for item in monitored_pvs %}
+          <tr>
+          {% if item.data %}<td><a href='javascript:void(0);' onClick="new_monitor('{{ item.key }}', '2');"> {{ item.key }} </a></td>{% else %}<td>{{ item.key }}</td>{% endif %}
+          <td>{{ item.value }}</td>
+          <td><span class="inlinesparkline">{{ item.data }}</span></td>
+          <td>{{ item.timestamp }}</td>
+          </tr>
+      {% endfor %}
+      </tbody>
+      </table>
+      <br>
+   </div>
+{% endif %}
+</span>

--- a/src/webmon_app/reporting/templates/report/base_instrument.html
+++ b/src/webmon_app/reporting/templates/report/base_instrument.html
@@ -41,6 +41,7 @@ Last experiment: <a href='{{ base_ipts_url }}{{ last_expt.expt_name }}/'>{{ last
 {% endif %}
 </p>
 
+<span id='monitored_pv_table'></span>
 {% endblock %}
 
 {% block right_side_links %}

--- a/src/webmon_app/reporting/templates/report/base_instrument.html
+++ b/src/webmon_app/reporting/templates/report/base_instrument.html
@@ -41,7 +41,7 @@ Last experiment: <a href='{{ base_ipts_url }}{{ last_expt.expt_name }}/'>{{ last
 {% endif %}
 </p>
 
-<span id='monitored_pv_table'></span>
+<div id='monitored_pv_table'></div>
 {% endblock %}
 
 {% block right_side_links %}

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view.py
@@ -2,9 +2,11 @@ import pytest
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from workflow.database.report.models import IPTS, DataRun, WorkflowSummary
 
 from reporting.dasmon.models import ActiveInstrument, Instrument
+from reporting.pvmon.models import MonitoredVariable, PVCache, PVName
 
 
 class DashboardViewTest(TestCase):
@@ -343,6 +345,68 @@ class LiveMonitorViewTest(TestCase):
         response = self.client.get(reverse("dasmon:live_monitor", args=["test_instrument"]))
         self.assertEqual(response.status_code, 200)
         assert "test_instrument" in str(response.context)
+
+    def test_monitored_pv_table_placeholder_present(self):
+        """The status page must provide the element the monitored PV table is loaded into"""
+        response = self.client.get(reverse("dasmon:live_monitor", args=["test_instrument"]))
+        self.assertEqual(response.status_code, 200)
+        assert "monitored_pv_table" in response.content.decode()
+
+
+class GetMonitoredPVTableViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User.objects.create_superuser(username="testuser", password="12345").save()
+        inst = Instrument.objects.create(name="test_instrument")
+        inst.save()
+        ActiveInstrument.objects.create(
+            instrument_id=inst,
+            is_alive=True,
+            is_adara=True,
+            has_pvsd=True,
+            has_pvstreamer=True,
+        )
+        pvname = PVName.objects.create(name="BeamPower")
+        PVCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value=1100.0,
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+    @classmethod
+    def tearDownClass(cls):
+        User.objects.get(username="testuser").delete()
+        Instrument.objects.get(name="test_instrument").delete()
+        MonitoredVariable.objects.all().delete()
+        PVCache.objects.all().delete()
+        PVName.objects.all().delete()
+
+    def setUp(self):
+        self.assertTrue(self.client.login(username="testuser", password="12345"))
+
+    def test_view_url_exists_at_desired_location(self):
+        response = self.client.get("/dasmon/test_instrument/monitored_pvs/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_url_accessible_by_name(self):
+        response = self.client.get(reverse("dasmon:get_monitored_pv_table", args=["test_instrument"]))
+        self.assertEqual(response.status_code, 200)
+
+    def test_monitored_pv_is_rendered(self):
+        response = self.client.get(reverse("dasmon:get_monitored_pv_table", args=["test_instrument"]))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        assert "BeamPower" in content
+        assert "1100" in content
+
+    def test_unknown_instrument_does_not_render_a_table(self):
+        # login_or_local_required_401 turns the Http404 into a 500, which is the
+        # same behaviour as the other AJAX endpoints, e.g. dasmon:get_update
+        response = self.client.get(reverse("dasmon:get_monitored_pv_table", args=["no_such_instrument"]))
+        self.assertEqual(response.status_code, 500)
 
 
 class LiveRunsViewTest(TestCase):

--- a/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
+++ b/src/webmon_app/reporting/tests/test_dasmon/test_view_util.py
@@ -11,7 +11,7 @@ from workflow.database.report.models import IPTS, DataRun
 
 from reporting import dasmon, users
 from reporting.dasmon.models import ActiveInstrument, Parameter, StatusCache, StatusVariable
-from reporting.pvmon.models import PVCache, PVName
+from reporting.pvmon.models import MonitoredVariable, PVCache, PVName, PVStringCache
 from reporting.report.models import Error, Information, Instrument, RunStatus, StatusQueue, WorkflowSummary
 
 # make flake8 happy
@@ -1100,6 +1100,151 @@ class ViewUtilTest(TestCase):
         request.user.ldap_user = ldap_user
         inst_list = get_instruments_for_user(request)
         assert "TESTINST" in inst_list
+
+
+class GetMonitoredPVsTest(TestCase):
+    """Tests for the monitored PV table shown on the instrument status page"""
+
+    def _make_instrument(self, name):
+        inst = Instrument.objects.create(name=name)
+        inst.save()
+        return inst
+
+    def test_returns_monitored_pvs_sorted_by_name(self):
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_sorted")
+        for pv_name, value in [("zebra", 3.5), ("alpha", 1.25)]:
+            pvname = PVName.objects.create(name=pv_name)
+            PVCache.objects.create(
+                instrument=inst,
+                name=pvname,
+                value=value,
+                status=0,
+                timestamp=timezone.now(),
+            )
+            MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert [pv["key"] for pv in monitored_pvs] == ["alpha", "zebra"]
+        assert monitored_pvs[0]["value"] == "1.25"
+        assert monitored_pvs[1]["value"] == "3.5"
+
+    def test_returns_string_pv_values(self):
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_string")
+        pvname = PVName.objects.create(name="SampleName")
+        PVStringCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value="vanadium rod",
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert len(monitored_pvs) == 1
+        assert monitored_pvs[0]["key"] == "SampleName"
+        assert monitored_pvs[0]["value"] == "vanadium rod"
+
+    def test_skips_entries_without_a_pv_name(self):
+        """setInstrumentPVs stores a placeholder row when the PV list is empty"""
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_none")
+        MonitoredVariable.objects.create(instrument=inst, pv_name=None, rule_name="")
+        assert get_monitored_pvs(inst) == []
+
+        pvname = PVName.objects.create(name="BeamPower")
+        PVCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value=1100.0,
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert len(monitored_pvs) == 1
+        assert monitored_pvs[0]["key"] == "BeamPower"
+
+    def test_monitored_pv_without_cached_value(self):
+        """A PV can be monitored before any value has been received for it"""
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_novalue")
+        pvname = PVName.objects.create(name="Wavelength")
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert len(monitored_pvs) == 1
+        assert monitored_pvs[0]["value"] == "No data available"
+        assert monitored_pvs[0]["timestamp"] == "-"
+
+    def test_only_returns_pvs_for_the_requested_instrument(self):
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_mine")
+        other_inst = self._make_instrument("testinst_monpvs_other")
+        for instrument, pv_name in [(inst, "MyPV"), (other_inst, "TheirPV")]:
+            pvname = PVName.objects.create(name=pv_name)
+            PVCache.objects.create(
+                instrument=instrument,
+                name=pvname,
+                value=1.0,
+                status=0,
+                timestamp=timezone.now(),
+            )
+            MonitoredVariable.objects.create(instrument=instrument, pv_name=pvname, rule_name="")
+
+        assert [pv["key"] for pv in get_monitored_pvs(inst)] == ["MyPV"]
+
+    def test_no_monitored_pvs(self):
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_empty")
+        assert get_monitored_pvs(inst) == []
+
+    def test_numeric_pv_has_history_for_the_sparkline(self):
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_history")
+        pvname = PVName.objects.create(name="BeamPower")
+        PVCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value=1100.0,
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert len(monitored_pvs) == 1
+        # The history drives the inline sparkline and the link to the plot dialog
+        assert "1100" in monitored_pvs[0]["data"]
+
+    def test_string_pv_has_no_history(self):
+        """String PVs cannot be plotted, so they get no sparkline"""
+        from reporting.dasmon.view_util import get_monitored_pvs
+
+        inst = self._make_instrument("testinst_monpvs_nohistory")
+        pvname = PVName.objects.create(name="SampleName")
+        PVStringCache.objects.create(
+            instrument=inst,
+            name=pvname,
+            value="vanadium rod",
+            status=0,
+            timestamp=timezone.now(),
+        )
+        MonitoredVariable.objects.create(instrument=inst, pv_name=pvname, rule_name="")
+
+        monitored_pvs = get_monitored_pvs(inst)
+        assert len(monitored_pvs) == 1
+        assert monitored_pvs[0]["data"] == ""
 
 
 if __name__ == "__main__":

--- a/src/webmon_app/reporting/tests/test_pvmon/test_models.py
+++ b/src/webmon_app/reporting/tests/test_pvmon/test_models.py
@@ -26,13 +26,13 @@ class PVTest(TestCase):
         instrument.save()
         pvname = PVName.objects.create(name="testPV")
         pvname.save()
-        PV.objects.create(
+        cls.pv_id = PV.objects.create(
             instrument=instrument,
             name=pvname,
             value=1.0,
             status=0,
             timestamp=datetime.fromisoformat("2011-11-04T00:05:23Z"),
-        )
+        ).id
 
     @classmethod
     def tearDownClass(cls):
@@ -40,15 +40,15 @@ class PVTest(TestCase):
         PVName.objects.get(name="testPV").delete()
 
     def test_value(self):
-        pv = PV.objects.get(id=1)
+        pv = PV.objects.get(id=self.pv_id)
         self.assertEqual(pv.value, 1.0)
 
     def test_status(self):
-        pv = PV.objects.get(id=1)
+        pv = PV.objects.get(id=self.pv_id)
         self.assertEqual(pv.status, 0)
 
     def test_timestamp(self):
-        pv = PV.objects.get(id=1)
+        pv = PV.objects.get(id=self.pv_id)
         self.assertEqual(pv.timestamp, datetime.fromisoformat("2011-11-04T00:05:23Z"))
 
 
@@ -59,13 +59,13 @@ class PVCacheTest(TestCase):
         instrument.save()
         pvname = PVName.objects.create(name="testPV")
         pvname.save()
-        PVCache.objects.create(
+        cls.pv_id = PVCache.objects.create(
             instrument=instrument,
             name=pvname,
             value=1.0,
             status=0,
             timestamp=datetime.fromisoformat("2011-11-04T00:05:23Z"),
-        )
+        ).id
 
     @classmethod
     def tearDownClass(cls):
@@ -73,15 +73,15 @@ class PVCacheTest(TestCase):
         PVName.objects.get(name="testPV").delete()
 
     def test_value(self):
-        pv = PVCache.objects.get(id=1)
+        pv = PVCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.value, 1.0)
 
     def test_status(self):
-        pv = PVCache.objects.get(id=1)
+        pv = PVCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.status, 0)
 
     def test_timestamp(self):
-        pv = PVCache.objects.get(id=1)
+        pv = PVCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.timestamp, datetime.fromisoformat("2011-11-04T00:05:23Z"))
 
 
@@ -92,13 +92,13 @@ class PVStringCacheTest(TestCase):
         instrument.save()
         pvname = PVName.objects.create(name="testPV")
         pvname.save()
-        PVStringCache.objects.create(
+        cls.pv_id = PVStringCache.objects.create(
             instrument=instrument,
             name=pvname,
             value="test",
             status=0,
             timestamp=datetime.fromisoformat("2011-11-04T00:05:23Z"),
-        )
+        ).id
 
     @classmethod
     def tearDownClass(cls):
@@ -106,15 +106,15 @@ class PVStringCacheTest(TestCase):
         PVName.objects.get(name="testPV").delete()
 
     def test_value(self):
-        pv = PVStringCache.objects.get(id=1)
+        pv = PVStringCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.value, "test")
 
     def test_status(self):
-        pv = PVStringCache.objects.get(id=1)
+        pv = PVStringCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.status, 0)
 
     def test_timestamp(self):
-        pv = PVStringCache.objects.get(id=1)
+        pv = PVStringCache.objects.get(id=self.pv_id)
         self.assertEqual(pv.timestamp, datetime.fromisoformat("2011-11-04T00:05:23Z"))
 
 
@@ -125,11 +125,11 @@ class MonitoredVariableTest(TestCase):
         instrument.save()
         pvname = PVName.objects.create(name="testPV")
         pvname.save()
-        MonitoredVariable.objects.create(
+        cls.monitored_variable_id = MonitoredVariable.objects.create(
             instrument=instrument,
             pv_name=pvname,
             rule_name="testRule",
-        )
+        ).id
 
     @classmethod
     def tearDownClass(cls):
@@ -137,33 +137,33 @@ class MonitoredVariableTest(TestCase):
         PVName.objects.get(name="testPV").delete()
 
     def test_rule_name(self):
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         self.assertEqual(pv.rule_name, "testRule")
 
     def test_rule_name_max_length(self):
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         max_len = pv._meta.get_field("rule_name").max_length
         self.assertEqual(max_len, 50)
 
     def test_created_field_exists(self):
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         self.assertTrue(hasattr(pv, "created"))
         self.assertIsNotNone(pv.created)
 
     def test_updated_field_exists(self):
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         self.assertTrue(hasattr(pv, "updated"))
         self.assertIsNotNone(pv.updated)
 
     def test_created_auto_now_add(self):
         # Test that created field has auto_now_add=True
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         created_field = pv._meta.get_field("created")
         self.assertTrue(created_field.auto_now_add)
 
     def test_updated_auto_now(self):
         # Test that updated field has auto_now=True
-        pv = MonitoredVariable.objects.get(id=1)
+        pv = MonitoredVariable.objects.get(id=self.monitored_variable_id)
         updated_field = pv._meta.get_field("updated")
         self.assertTrue(updated_field.auto_now)
 


### PR DESCRIPTION
# Description of the changes

The PVs that beamlines select through the `MonitorPVs` IOC stopped showing up on the instrument status page. The PVs themselves were being stored correctly — DASMON calls the `setInstrumentPVs` stored procedure, and `pvmon_monitoredvariable` had rows updated the same day — so the problem was on the display side: nothing read that table any more.

The only code that read `MonitoredVariable` for display was `get_signals()` in `dasmon/view_util.py`. Besides collecting DASMON signals, it also collected the monitored PVs and their latest values, and `signal_table.html` rendered both. Removing the obsolete ADARA signal handling in #297 therefore took the monitored PV table with it. The same commit also dropped the `option === "2"` branch of `poll()` in `live_monitor.html`, which is what plots a monitored PV's history when you click it — so two things broke, not one.

Both are restored here without bringing back any of the signal handling:

- `get_monitored_pvs()` in `dasmon/view_util.py` reads `MonitoredVariable` and pairs each PV with its latest value from `PVCache`/`PVStringCache` plus its recent history.
- New `dasmon:get_monitored_pv_table` AJAX endpoint and `monitored_pv_table.html`, replacing the deleted `signal_table.html`.
- The table renders above the status variables again, and the polling that refreshes it and plots monitored PV history is back.

Two edge cases worth knowing about: rows with no PV attached are skipped, because `setInstrumentPVs` writes a placeholder row when an instrument's list is empty; and a PV that is monitored but has not reported a value yet is shown as "No data available" rather than dropped.

Two things that go slightly beyond the fix:

- The new endpoint is cached for `FAST_PAGE_CACHE_TIMEOUT` (10 s in prod). The old signal table was deliberately uncached because users could clear alarms and stale entries would briefly reappear. There is no interaction now, so caching is safe and saves a query per poll.
- Several tests in `test_pvmon/test_models.py` looked up objects by a hard-coded `id=1`. They broke as soon as new tests created rows of the same models, so they now use the id of the object they create.

Check all that apply:
- [x] updated documentation
- [x] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests
- [ ] (If applicable) Verified that manual tests requiring the /SNS and /HFIR filesystems pass without fail

**References:**
- Links to IBM EWM items: EWM 17275
- Links to related issues or pull requests: #297 (the change this regressed from)

# :warning: Manual test for the reviewer

Bring up the local deployment (`pixi run all && pixi run localdev-up`), then set a list of monitored PVs for `hysa` the same way DASMON does:

```
docker exec data_workflow-webmon-1 pixi run -e webmon python -c "
import django; django.setup()
from django.db import connection
with connection.cursor() as c:
    c.execute(\"select setInstrumentPVs(%s::text, %s::text[])\", ['hysa', ['sinPV', 'sawtoothPV', 'xString']])
"
```

Then log in and open `/dasmon/hysa/`. Please confirm:

- A "Monitored PV" table appears **above** the Key/Value status table, listing the three PVs with their values and timestamps.
- `sinPV` and `sawtoothPV` are links and show an inline sparkline; `xString` is plain text with no sparkline, since string PVs cannot be plotted.
- Clicking `sinPV` opens the plot dialog and the plot keeps updating (the page polls every 5 s).
- Re-running the command above with a shorter list removes the dropped PVs from the table.

Also worth a look: the `<span id='monitored_pv_table'></span>` placeholder lives in `base_instrument.html`, so it is present but stays empty on the other instrument pages — same as before #297.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent